### PR TITLE
The client of the test fixture and others fixes

### DIFF
--- a/include/graft_manager.h
+++ b/include/graft_manager.h
@@ -81,6 +81,7 @@ struct ServerOpts
     double http_connection_timeout;
     int workers_count;
     int worker_queue_len;
+    std::string cryptonode_rpc_address;
 };
 
 class Manager
@@ -110,7 +111,7 @@ public:
     ThreadPoolX& get_threadPool() { return *m_threadPool.get(); }
     TPResQueue& get_resQueue() { return *m_resQueue.get(); }
     GlobalContextMap& get_gcm() { return m_gcm; }
-    ServerOpts& get_opts() { return m_sopts; }
+    const ServerOpts& get_c_opts() const { return m_sopts; }
 
     ////static functions
     static void cb_event(mg_mgr* mgr, uint64_t cnt);
@@ -262,17 +263,6 @@ public:
 #endif
 public:
     void serve(mg_mgr* mgr);
-    /**
-   * @brief setCryptonodeRpcAddress - setup cryptonode RPC address
-   * @param address - address in IP:port form
-   */
-    void setCryptonodeRPCAddress(const std::string &address);
-    /**
-   * @brief setCryptonodeP2PAddress - setup cryptonode P2P address
-   * @param address - address in IP:port form
-   */
-    void setCryptonodeP2PAddress(const std::string &address);
-
 private:
     static void ev_handler_empty(mg_connection *client, int ev, void *ev_data);
     static void ev_handler_http(mg_connection *client, int ev, void *ev_data);

--- a/src/graft_manager.cpp
+++ b/src/graft_manager.cpp
@@ -141,7 +141,8 @@ void CryptoNodeSender::send(Manager &manager, ClientRequest_ptr cr, const std::s
 {
     m_cr = cr;
     m_data = data;
-    m_crypton = mg_connect(manager.get_mg_mgr(),"localhost:1234", static_ev_handler);
+    const ServerOpts& opts = manager.get_c_opts();
+    m_crypton = mg_connect(manager.get_mg_mgr(), opts.cryptonode_rpc_address.c_str(), static_ev_handler);
     m_crypton->user_data = this;
     //len + data
     help_send_pstring(m_crypton, m_data);
@@ -352,7 +353,7 @@ constexpr std::pair<const char *, int> GraftServer::m_methods[];
 
 void GraftServer::serve(mg_mgr *mgr)
 {
-    ServerOpts& opts = Manager::from(mgr)->get_opts();
+    const ServerOpts& opts = Manager::from(mgr)->get_c_opts();
 
     mg_connection *nc_http = mg_bind(mgr, opts.http_address.c_str(), ev_handler_http),
                   *nc_coap = mg_bind(mgr, opts.coap_address.c_str(), ev_handler_coap);
@@ -369,16 +370,6 @@ void GraftServer::serve(mg_mgr *mgr)
         if(Manager::from(mgr)->exit) break;
     }
     mg_mgr_free(mgr);
-}
-
-void GraftServer::setCryptonodeRPCAddress(const std::string &address)
-{
-    // TODO implement me
-}
-
-void GraftServer::setCryptonodeP2PAddress(const std::string &address)
-{
-    // TODO implement me
 }
 
 int GraftServer::translateMethod(const char *method, std::size_t len)
@@ -441,7 +432,7 @@ void GraftServer::ev_handler_http(mg_connection *client, int ev, void *ev_data)
     }
     case MG_EV_ACCEPT:
     {
-        ServerOpts& opts = manager->get_opts();
+        const ServerOpts& opts = manager->get_c_opts();
 
         mg_set_timer(client, mg_time() + opts.http_connection_timeout);
         break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,9 +74,6 @@ int main(int argc, const char** argv)
         // 3. address <IP>:<PORT>
         // 4. workers-count <integer>
         // 5. worker-queue-len <integer>
-        const boost::property_tree::ptree& cryptonode_conf = config.get_child("cryptonode");
-        const std::string cryptonode_rpc_address = cryptonode_conf.get<string>("rpc-address");
-        const std::string cryptonode_p2p_address = cryptonode_conf.get<string>("p2p-address");
 
         graft::ServerOpts sopts;
 
@@ -86,6 +83,9 @@ int main(int argc, const char** argv)
         sopts.http_connection_timeout = server_conf.get<double>("http-connection-timeout");
         sopts.workers_count = server_conf.get<int>("workers-count");
         sopts.worker_queue_len = server_conf.get<int>("worker-queue-len");
+        const boost::property_tree::ptree& cryptonode_conf = config.get_child("cryptonode");
+        sopts.cryptonode_rpc_address = cryptonode_conf.get<string>("rpc-address");
+        //sopts.cryptonode_p2p_address = cryptonode_conf.get<string>("p2p-address");
 
         graft::Manager manager(sopts);
 
@@ -94,10 +94,6 @@ int main(int argc, const char** argv)
         manager.enableRouting();
 
         graft::GraftServer server;
-
-        // setup cryptonode connection params
-        server.setCryptonodeP2PAddress(cryptonode_p2p_address);
-        server.setCryptonodeRPCAddress(cryptonode_rpc_address);
 
         LOG_PRINT_L0("Starting server on: [http] " << sopts.http_address << ", [coap] " << sopts.coap_address);
         server.serve(manager.get_mg_mgr());

--- a/test/graft_server_test.cpp
+++ b/test/graft_server_test.cpp
@@ -360,6 +360,7 @@ private:
         sopts.http_connection_timeout = .001;
         sopts.workers_count = 0;
         sopts.worker_queue_len = 0;
+        sopts.cryptonode_rpc_address = "127.0.0.1:1234";
 
         graft::Manager manager(sopts);
         pmanager = &manager;


### PR DESCRIPTION
- Some fixes of the client of test fixture.

- testSaleRequest and testSaleStatusRequest tests are using the client instead of curl.

- ServerOpts::cryptonode_rpc_address added

- GraftServerTest::Client:: serve and serve_json_res accept parameters 'const std:string&' instead of 'const char*'. Such signatures potentially enable adding faster mongoose functions (existing ones use strlen even when we know the sizes already)


