### PR TITLE
New functions added for routes debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ add_definitions(-DGN_ENABLE_EVENTFD=1 -DMG_USE_READ_WRITE)
 set(GS_SOURCES
     ${PROJECT_SOURCE_DIR}/src/graft_manager.cpp
     ${PROJECT_SOURCE_DIR}/src/inout.cpp
+    ${PROJECT_SOURCE_DIR}/src/router.cpp
     ${PROJECT_SOURCE_DIR}/src/requesttools.cpp
     ${PROJECT_SOURCE_DIR}/src/requestdefines.cpp
     ${PROJECT_SOURCE_DIR}/src/requests.cpp

--- a/include/graft_manager.h
+++ b/include/graft_manager.h
@@ -145,6 +145,11 @@ private:
 
     bool tryProcessReadyJob();
     void processReadyJobBlock();
+public:
+    std::string dbgDumpRouters() const { return m_root.dbgDumpRouters(); }
+    void dbgDumpR3Tree(int level = 0) const { return m_root.dbgDumpR3Tree(level); }
+    //returns conflicting endpoint
+    std::string dbgCheckConflictRoutes() const { return m_root.dbgCheckConflictRoutes(); }
 private:
     mg_mgr m_mgr;
     Router::Root m_root;

--- a/include/router.h
+++ b/include/router.h
@@ -64,7 +64,6 @@ public:
         bool match(const std::string& target, int method, JobParams& params);
         void addRouter(RouterT& r) { m_routers.push_front(std::move(r)); }
 
-    public:
         std::string dbgDumpRouters() const;
         void dbgDumpR3Tree(int level = 0) const;
         std::string dbgCheckConflictRoutes() const;

--- a/src/graft_manager.cpp
+++ b/src/graft_manager.cpp
@@ -471,7 +471,6 @@ int GraftServer::translateMethod(int i)
 {
     constexpr int size = sizeof(m_methods)/sizeof(m_methods[0]);
     assert(i<size);
-    //looks like it is problem here
     return m_methods[i].second;
 }
 
@@ -567,7 +566,6 @@ void GraftServer::ev_handler_coap(mg_connection *client, int ev, void *ev_data)
             }
         }
 
-        //not clear
         int method = translateMethod(cm->code_detail - 1);
 
         Router::JobParams prms;

--- a/src/graft_manager.cpp
+++ b/src/graft_manager.cpp
@@ -469,6 +469,9 @@ int GraftServer::translateMethod(const char *method, std::size_t len)
 
 int GraftServer::translateMethod(int i)
 {
+    constexpr int size = sizeof(m_methods)/sizeof(m_methods[0]);
+    assert(i<size);
+    //looks like it is problem here
     return m_methods[i].second;
 }
 
@@ -564,6 +567,7 @@ void GraftServer::ev_handler_coap(mg_connection *client, int ev, void *ev_data)
             }
         }
 
+        //not clear
         int method = translateMethod(cm->code_detail - 1);
 
         Router::JobParams prms;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,10 +113,11 @@ int main(int argc, const char** argv)
             {
                 std::cout << std::endl << "==> manager.dbgDumpRouters()" << std::endl;
                 std::cout << manager.dbgDumpRouters();
-/*
-                std::cout << std::endl << std::endl << "==> manager.dbgDumpR3Tree()" << std::endl;
-                manager.dbgDumpR3Tree();
-*/
+
+                //if you really need dump of r3tree uncomment two following lines
+                //std::cout << std::endl << std::endl << "==> manager.dbgDumpR3Tree()" << std::endl;
+                //manager.dbgDumpR3Tree();
+
                 throw std::runtime_error("Routes conflict found:" + s);
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,6 +107,20 @@ int main(int argc, const char** argv)
         graft::setHttpRouters(manager);
         manager.enableRouting();
 
+        {//check conflicts in routes
+            std::string s = manager.dbgCheckConflictRoutes();
+            if(!s.empty())
+            {
+                std::cout << std::endl << "==> manager.dbgDumpRouters()" << std::endl;
+                std::cout << manager.dbgDumpRouters();
+/*
+                std::cout << std::endl << std::endl << "==> manager.dbgDumpR3Tree()" << std::endl;
+                manager.dbgDumpR3Tree();
+*/
+                throw std::runtime_error("Routes conflict found:" + s);
+            }
+        }
+
         graft::GraftServer server;
 
         LOG_PRINT_L0("Starting server on: [http] " << sopts.http_address << ", [coap] " << sopts.coap_address);

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -1,0 +1,128 @@
+#include "router.h"
+
+namespace graft
+{
+
+template<typename In, typename Out>
+bool RouterT<In,Out>::Root::arm()
+{
+    std::for_each(m_routers.begin(), m_routers.end(),
+        [this](Router& ro)
+        {
+            std::for_each(ro.m_routes.begin(), ro.m_routes.end(),
+                [this](Route& r)
+                {
+                    r3_tree_insert_route(m_node, r.methods, r.endpoint.c_str(), &r);
+                }
+            );
+        }
+    );
+    char *errstr = NULL;
+    int err = r3_tree_compile(m_node, &errstr);
+
+    if (err != 0)
+        std::cout << "error: " << std::string(errstr) << std::endl;
+
+    return m_compiled = (err == 0);
+}
+
+template<typename In, typename Out>
+bool RouterT<In,Out>::Root::match(const std::string& target, int method, JobParams& params)
+{
+    bool ret = false;
+
+    match_entry *entry = match_entry_create(target.c_str());
+    entry->request_method = method;
+
+    R3Route *m = r3_tree_match_route(m_node, entry);
+    if (m)
+    {
+        for (size_t i = 0; i < entry->vars.tokens.size; i++)
+            params.vars.emplace_back(std::make_pair(
+                std::move(std::string(entry->vars.slugs.entries[i].base, entry->vars.slugs.entries[i].len)),
+                std::move(std::string(entry->vars.tokens.entries[i].base, entry->vars.tokens.entries[i].len))
+            ));
+
+        params.h3 = static_cast<Route*>(m->data)->h3;
+        ret = true;
+    }
+    match_entry_free(entry);
+    return ret;
+}
+
+template<typename In, typename Out>
+std::string RouterT<In,Out>::Root::dbgDumpRouters() const
+{
+    std::string res;
+    int idx = 0;
+    for(const RouterT& r : m_routers)
+    {
+        std::ostringstream ss;
+        ss << "router[" << idx++ << "]->" << std::endl;
+        res += ss.str();
+        res += r.dbgDumpRouter("\t");
+    }
+    return res;
+}
+
+template<typename In, typename Out>
+void RouterT<In,Out>::Root::dbgDumpR3Tree(int level) const
+{
+    assert(m_compiled);
+    r3_tree_dump(m_node, level);
+}
+
+template<typename In, typename Out>
+std::string RouterT<In,Out>::Root::dbgCheckConflictRoutes() const
+{
+    //route -> method bits
+    std::map<std::string,int> map;
+    for(const RouterT& r : m_routers)
+    {
+        for(const Route& rr : r.m_routes)
+        {
+            auto it = map.find(rr.endpoint);
+            if(it == map.end())
+            {
+                map[rr.endpoint] = rr.methods;
+                continue;
+            }
+            if(it->second & rr.methods) return rr.endpoint;
+            it->second &= rr.methods;
+        }
+    }
+}
+
+template<typename In, typename Out>
+std::string RouterT<In,Out>::dbgDumpRouter(const std::string prefix) const
+{
+    constexpr const char* methpow[] = {"", "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"};
+    std::ostringstream ss;
+    for(const Route& r : m_routes)
+    {
+        assert((r.methods&0xFE)==r.methods);
+        std::string sm;
+        for(unsigned int b=1, idx=0; idx<8; b<<=1, ++idx)
+        {
+            if(!(r.methods&b)) continue;
+            if(!sm.empty()) sm += '|';
+            sm += methpow[idx];
+        }
+        auto ptrs = [](auto& ptr)->std::string
+        {
+            if(ptr == nullptr) return "nullptr";
+            std::ostringstream ss;
+            ss << &ptr;
+            return ss.str();
+        };
+        ss << prefix << sm << " " << r.endpoint << " (" <<
+              ptrs(r.h3.pre_action) << "," <<
+              ptrs(r.h3.worker_action) << "," <<
+              ptrs(r.h3.post_action) << ")" << std::endl;
+    }
+    return ss.str();
+}
+
+template class RouterT<Input, Output>;
+
+}//namespace graft


### PR DESCRIPTION
There are two commits:
1. new debug functions one of which used to check routes conflicts
2. implementations of some functions in RouterT template moved into new router.cpp file

Also I have emphasized by comments possible issues with GraftServer::translateMethod
