### PR TITLE
Fix static linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ set(CRYPTONODE_LIBS
 set(COMMON_LIBS
     ssl
     crypto
+    readline
     )
 
 #set(Boost_USE_STATIC_LIBS ON)
@@ -228,6 +229,7 @@ if (OPT_BUILD_TESTS)
             ${GS_LIBS}
             ${Boost_LIBRARIES}
             ${CMAKE_THREAD_LIBS_INIT}
+            ${COMMON_LIBS}
             )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ ExternalProject_Add(
     STAMP_DIR ${PROJECT_BINARY_DIR}/STAMP/cryptonode
     TMP_DIR ${PROJECT_BINARY_DIR}/TMP/cryptonode
     INSTALL_DIR ${PROJECT_BINARY_DIR}/BUILD
-    CMAKE_ARGS ${ExternalProjectCMakeArgs} -DBUILD_SHARED_LIBS=ON # TODO: fix so cryptonode's libs can be statically linked
+    CMAKE_ARGS ${ExternalProjectCMakeArgs}
     )
 
 set(CMAKE_CXX_STANDARD 14)
@@ -107,6 +107,7 @@ set(CRYPTONODE_INCLUDE_DIRS
 set(CRYPTONODE_LIB_DIRS
     ${PROJECT_BINARY_DIR}/BUILD/cryptonode/contrib/epee/src
     ${PROJECT_BINARY_DIR}/BUILD/cryptonode/external/easylogging++
+    ${PROJECT_BINARY_DIR}/BUILD/cryptonode/external/unbound
     ${PROJECT_BINARY_DIR}/BUILD/cryptonode/lib
     ${PROJECT_BINARY_DIR}/BUILD/cryptonode/src/common
     ${PROJECT_BINARY_DIR}/BUILD/cryptonode/src/crypto
@@ -119,18 +120,20 @@ set(CRYPTONODE_LIB_DIRS
 
 set(CRYPTONODE_LIBS
     easylogging
+    wallet
+    mnemonics
+    ringct
     epee
     cryptonote_core
     cryptonote_basic
-    cncrypto
-    wallet # if linked statically: once we add any call to this library from source code, weird linker errors happening
-    mnemonics
-    ringct
     common
+    unbound
+    cncrypto
     )
 
 set(COMMON_LIBS
-    readline
+    ssl
+    crypto
     )
 
 #set(Boost_USE_STATIC_LIBS ON)
@@ -171,7 +174,7 @@ target_link_libraries(graft_server PRIVATE
     ${Boost_SERIALIZATION_LIBRARY}
     ${Boost_THREAD_LIBRARY}
     ${Boost_REGEX_LIBRARY}
-
+    ${COMMON_LIBS}
     )
 target_compile_definitions(graft_server PRIVATE MG_ENABLE_COAP=1)
 


### PR DESCRIPTION
boris@ub18:~/gitrepos/graft-ng/tmp$ ldd ./graft_server
	linux-vdso.so.1 (0x00007ffc036d2000)
	libpcre.so.3 => /lib/x86_64-linux-gnu/libpcre.so.3 (0x00007fb4d77ad000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fb4d75a9000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fb4d738a000)
	libboost_program_options.so.1.65.1 => /usr/lib/x86_64-linux-gnu/libboost_program_options.so.1.65.1 (0x00007fb4d7109000)
	libboost_filesystem.so.1.65.1 => /usr/lib/x86_64-linux-gnu/libboost_filesystem.so.1.65.1 (0x00007fb4d6eef000)
	libboost_system.so.1.65.1 => /usr/lib/x86_64-linux-gnu/libboost_system.so.1.65.1 (0x00007fb4d6cea000)
	libboost_serialization.so.1.65.1 => /usr/lib/x86_64-linux-gnu/libboost_serialization.so.1.65.1 (0x00007fb4d6aac000)
	libboost_thread.so.1.65.1 => /usr/lib/x86_64-linux-gnu/libboost_thread.so.1.65.1 (0x00007fb4d6887000)
	libboost_regex.so.1.65.1 => /usr/lib/x86_64-linux-gnu/libboost_regex.so.1.65.1 (0x00007fb4d657f000)
	libssl.so.1.1 => /usr/lib/x86_64-linux-gnu/libssl.so.1.1 (0x00007fb4d6315000)
	libcrypto.so.1.1 => /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 (0x00007fb4d5e9d000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fb4d5b0f000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fb4d5771000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fb4d5559000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fb4d5168000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fb4d82d0000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fb4d4f60000)
	libicui18n.so.60 => /usr/lib/x86_64-linux-gnu/libicui18n.so.60 (0x00007fb4d4abf000)
	libicuuc.so.60 => /usr/lib/x86_64-linux-gnu/libicuuc.so.60 (0x00007fb4d4708000)
	libicudata.so.60 => /usr/lib/x86_64-linux-gnu/libicudata.so.60 (0x00007fb4d2b5f000)
