### PR TITLE
Terminate handler added

### DIFF
--- a/include/router.h
+++ b/include/router.h
@@ -87,6 +87,8 @@ public:
         m_routes.push_front(r);
     }
 
+    // Please read the comment about exceptions and noexcept specifier
+    // near 'void terminate()' function in main.cpp
     void addRoute(const std::string& endpoint, int methods, const Handler3&& ph3)
     {
         m_routes.push_front({m_endpointPrefix + endpoint, methods, std::move(ph3)});

--- a/include/thread_pool.h
+++ b/include/thread_pool.h
@@ -48,6 +48,8 @@ public:
 
             try
             {
+                // Please read the comment about exceptions and noexcept specifier
+                // near 'void terminate()' function in main.cpp
                 Status status = h3_ref.worker_action(vars_cref, input_ref, ctx, output_ref);
                 Context::LocalFriend::setLastStatus(ctx.local, status);
                 if(Status::Ok == status && h3_ref.post_action || Status::Forward == status)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,10 @@ namespace graft
 
 std::terminate_handler prev_terminate = nullptr;
 
+// Unhandled exception in a handler with noexcept specifier causes
+// termination of the program, stack backtrace is created upon the termination.
+// The exception in a handler with no noexcept specifier doesn't effect
+// the workflow, the error propagates back to the client.
 void terminate()
 {
     std::cerr << "\nTerminate called, dump stack:\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,43 @@
 #include "server.h"
+#include "backtrace.h"
+
+namespace graft
+{
+
+std::terminate_handler prev_terminate = nullptr;
+
+void terminate()
+{
+    std::cerr << "\nTerminate called, dump stack:\n";
+    graft_bt();
+
+    //dump exception info
+    std::exception_ptr eptr = std::current_exception();
+    if(eptr)
+    {
+        try
+        {
+             std::rethrow_exception(eptr);
+        }
+        catch(std::exception& ex)
+        {
+            std::cerr << "\nTerminate caused by exception : '" << ex.what() << "'\n";
+        }
+        catch(...)
+        {
+            std::cerr << "\nTerminate caused by unknown exception.\n";
+        }
+    }
+
+    prev_terminate();
+}
+
+} //namespace graft
 
 int main(int argc, const char** argv)
 {
+    graft::prev_terminate = std::set_terminate( graft::terminate );
+
     try
     {
         graft::GraftServer gserver;

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -142,6 +142,8 @@ void TaskManager::ExecutePreAction(BaseTaskPtr bt)
 
     try
     {
+        // Please read the comment about exceptions and noexcept specifier
+        // near 'void terminate()' function in main.cpp
         Status status = params.h3.pre_action(params.vars, params.input, ctx, output);
         bt->setLastStatus(status);
         if(Status::Ok == status && (params.h3.worker_action || params.h3.post_action)
@@ -179,6 +181,8 @@ void TaskManager::ExecutePostAction(BaseTaskPtr bt, GJ* gj)
 
     try
     {
+        // Please read the comment about exceptions and noexcept specifier
+        // near 'void terminate()' function in main.cpp
         Status status = params.h3.post_action(params.vars, params.input, ctx, output);
         bt->setLastStatus(status);
         if(Status::Forward == status)


### PR DESCRIPTION
If you want that an exception in your handler causes termination of the program, just add noexcept specifier at the end of your handler, like following:

_auto action = [](const graft::Router::vars_t& vars, const graft::Input& input, graft::Context& ctx, graft::Output& output) **noexcept** -> graft::Status
    {
        throw 1;
        return graft::Status::Ok;
    };_

The terminate handler will be called that dump the stack information before termination.

If you want to prevent termination in a part of handler then wrap it with try - catch statements.

But if you don't place noexcept a client have a chance to get the description of an exception. In this case the program won't be terminated.