### PR TITLE
Fix cmake error when boost not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ set(COMMON_LIBS
 find_package(Boost 1.65 QUIET REQUIRED COMPONENTS system filesystem program_options serialization thread regex)
 
 if(NOT Boost_FOUND)
-    die("Could not find Boost libraries, please make sure you have installed Boost or libboost-all-dev (1.65) or the equivalent")
+    message(FATAL_ERROR "Could not find Boost libraries, please make sure you have installed Boost or libboost-all-dev (1.65) or the equivalent")
 elseif(Boost_FOUND)
     message(STATUS "Found Boost Version: ${Boost_VERSION}")
 endif()


### PR DESCRIPTION
`die(...)` should be `message(FATAL_ERROR ...)`



Without this change having boost missing or too old results in:

```
CMake Error at CMakeLists.txt:154 (die):
  Unknown CMake command "die".
```

instead of (with the fix):

```
CMake Error at CMakeLists.txt:154 (message):
  Could not find Boost libraries, please make sure you have installed Boost
  or libboost-all-dev (1.65) or the equivalent
```