### PR TITLE
Supernode should not crash with assert when postponed task not found

### DIFF
--- a/src/task.cpp
+++ b/src/task.cpp
@@ -238,6 +238,7 @@ void TaskManager::postponeTask(BaseTaskPtr bt)
                                     tpoint,
                                     uuid)
                                 );
+    LOG_PRINT_RQS_BT(2,bt,"task with uuid '" << uuid << "' postponed.");
 }
 
 void TaskManager::executePostponedTasks()
@@ -245,6 +246,8 @@ void TaskManager::executePostponedTasks()
     while(!m_readyToResume.empty())
     {
         BaseTaskPtr& bt = m_readyToResume.front();
+        Context::uuid_t uuid = bt->getCtx().getId();
+        LOG_PRINT_RQS_BT(2,bt,"task with uuid '" << uuid << "' resumed.");
         Execute(bt);
         m_readyToResume.pop_front();
     }
@@ -261,6 +264,8 @@ void TaskManager::executePostponedTasks()
         if(it != m_postponedTasks.end())
         {
             BaseTaskPtr& bt = it->second;
+            Context::uuid_t uuid = bt->getCtx().getId();
+            LOG_PRINT_RQS_BT(2,bt,"postponed task with uuid '" << uuid << "' expired.");
             std::string msg = "Postpone task response timeout";
             bt->setError(msg.c_str(), Status::Error);
             respondAndDie(bt, msg);
@@ -289,9 +294,16 @@ void TaskManager::processResult(BaseTaskPtr bt)
         if(!nextUuid.is_nil())
         {
             auto it = m_postponedTasks.find(nextUuid);
-            assert(it != m_postponedTasks.end());
-            m_readyToResume.push_back(it->second);
-            m_postponedTasks.erase(it);
+            if(it == m_postponedTasks.end())
+            {
+                LOG_PRINT_RQS_BT(2,bt,"attempt to resume task with uuid '" << nextUuid << "' failed, maybe it is not postponed yet.");
+            }
+            else
+            {
+                LOG_PRINT_RQS_BT(2,bt,"resuming task with uuid '" << nextUuid << "'.");
+                m_readyToResume.push_back(it->second);
+                m_postponedTasks.erase(it);
+            }
         }
         respondAndDie(bt, bt->getOutput().data());
     } break;

--- a/test/graft_server_test.cpp
+++ b/test/graft_server_test.cpp
@@ -1188,7 +1188,10 @@ TEST_F(GraftServerCommonTest, clPOSTtpCNtp)
     }
 }
 
-TEST_F(GraftServerCommonTest, testSaleRequest)
+//The following "GraftServerCommonTest.test*" tests are obsolete and are made
+//DISABLED_, because endpoints or handlers behaviors they use have been changed.
+
+TEST_F(GraftServerCommonTest, DISABLED_testSaleRequest)
 {
     std::string sale_url(dapi_url + "/sale");
     graft::Input response;
@@ -1224,7 +1227,7 @@ TEST_F(GraftServerCommonTest, testSaleRequest)
     EXPECT_EQ(custom_pid, sale_response.PaymentID);
 }
 
-TEST_F(GraftServerCommonTest, testSaleStatusRequest)
+TEST_F(GraftServerCommonTest, DISABLED_testSaleStatusRequest)
 {
     std::string sale_status_url(dapi_url + "/sale_status");
     graft::Input response;
@@ -1247,7 +1250,7 @@ TEST_F(GraftServerCommonTest, testSaleStatusRequest)
     EXPECT_EQ(MESSAGE_PAYMENT_ID_INVALID, error_response.message);
 }
 
-TEST_F(GraftServerCommonTest, testRejectSaleRequest)
+TEST_F(GraftServerCommonTest, DISABLED_testRejectSaleRequest)
 {
     std::string reject_sale_url(dapi_url + "/reject_sale");
     graft::Input response;
@@ -1270,7 +1273,7 @@ TEST_F(GraftServerCommonTest, testRejectSaleRequest)
     EXPECT_EQ(MESSAGE_PAYMENT_ID_INVALID, error_response.message);
 }
 
-TEST_F(GraftServerCommonTest, testSaleDetailsRequest)
+TEST_F(GraftServerCommonTest, DISABLED_testSaleDetailsRequest)
 {
     std::string sale_details_url(dapi_url + "/sale_details");
     graft::Input response;
@@ -1293,7 +1296,7 @@ TEST_F(GraftServerCommonTest, testSaleDetailsRequest)
     EXPECT_EQ(MESSAGE_PAYMENT_ID_INVALID, error_response.message);
 }
 
-TEST_F(GraftServerCommonTest, testPayRequest)
+TEST_F(GraftServerCommonTest, DISABLED_testPayRequest)
 {
     std::string pay_url(dapi_url + "/pay");
     graft::Input response;
@@ -1348,7 +1351,7 @@ TEST_F(GraftServerCommonTest, testPayRequest)
     EXPECT_EQ(MESSAGE_AMOUNT_INVALID, error_response.message);
 }
 
-TEST_F(GraftServerCommonTest, testPayStatusRequest)
+TEST_F(GraftServerCommonTest, DISABLED_testPayStatusRequest)
 {
     std::string pay_status_url(dapi_url + "/pay_status");
     graft::Input response;
@@ -1371,7 +1374,7 @@ TEST_F(GraftServerCommonTest, testPayStatusRequest)
     EXPECT_EQ(MESSAGE_PAYMENT_ID_INVALID, error_response.message);
 }
 
-TEST_F(GraftServerCommonTest, testRejectPayRequest)
+TEST_F(GraftServerCommonTest, DISABLED_testRejectPayRequest)
 {
     std::string reject_pay_url(dapi_url + "/reject_pay");
     graft::Input response;
@@ -1394,7 +1397,7 @@ TEST_F(GraftServerCommonTest, testRejectPayRequest)
     EXPECT_EQ(MESSAGE_PAYMENT_ID_INVALID, error_response.message);
 }
 
-TEST_F(GraftServerCommonTest, testRTARejectSaleFlow)
+TEST_F(GraftServerCommonTest, DISABLED_testRTARejectSaleFlow)
 {
     graft::Input response;
     std::string res;
@@ -1431,7 +1434,7 @@ TEST_F(GraftServerCommonTest, testRTARejectSaleFlow)
     EXPECT_EQ(static_cast<int>(graft::RTAStatus::RejectedByPOS), sale_status_response.Status);
 }
 
-TEST_F(GraftServerCommonTest, testRTARejectPayFlow)
+TEST_F(GraftServerCommonTest, DISABLED_testRTARejectPayFlow)
 {
     graft::Input response;
     std::string res;
@@ -1483,7 +1486,7 @@ TEST_F(GraftServerCommonTest, testRTARejectPayFlow)
     EXPECT_EQ(static_cast<int>(graft::RTAStatus::RejectedByWallet), pay_status_response.Status);
 }
 
-TEST_F(GraftServerCommonTest, testRTAFailedPayment)
+TEST_F(GraftServerCommonTest, DISABLED_testRTAFailedPayment)
 {
     graft::Input response;
     std::string res;
@@ -1529,7 +1532,7 @@ TEST_F(GraftServerCommonTest, testRTAFailedPayment)
     EXPECT_EQ(MESSAGE_RTA_FAILED, error_response.message);
 }
 
-TEST_F(GraftServerCommonTest, testRTACompletedPayment)
+TEST_F(GraftServerCommonTest, DISABLED_testRTACompletedPayment)
 {
     graft::Input response;
     std::string res;
@@ -1575,7 +1578,7 @@ TEST_F(GraftServerCommonTest, testRTACompletedPayment)
     EXPECT_EQ(MESSAGE_RTA_COMPLETED, error_response.message);
 }
 
-TEST_F(GraftServerCommonTest, testRTAFullFlow)
+TEST_F(GraftServerCommonTest, DISABLED_testRTAFullFlow)
 {
     graft::Input response;
     std::string res;


### PR DESCRIPTION
- The assert replaced with logging messages. Some other logging messages concerning to postpone are added.

- Obsolete tests are DISABLED_