### PR TITLE
Added mising return values

### DIFF
--- a/src/requests/authorizertatxrequest.cpp
+++ b/src/requests/authorizertatxrequest.cpp
@@ -146,6 +146,7 @@ bool signAuthResponse(AuthorizeRtaTxResponse &arg, const SupernodePtr &supernode
     supernode->signHash(tx_id, sign);
     arg.signature.tx_signature = epee::string_tools::pod_to_hex(sign);
     arg.signature.address = supernode->walletAddress();
+    return true;
 }
 
 /*!

--- a/src/rta/fullsupernodelist.cpp
+++ b/src/rta/fullsupernodelist.cpp
@@ -189,7 +189,7 @@ size_t FullSupernodeList::loadFromDirThreaded(const string &base_dir, size_t &fo
 bool FullSupernodeList::remove(const string &address)
 {
     boost::unique_lock<boost::shared_mutex> readerLock(m_access);
-    m_list.erase(address) > 0;
+    return m_list.erase(address) > 0;
 }
 
 size_t FullSupernodeList::size() const


### PR DESCRIPTION
The `signAuthResponse` missing return value, in particular, was causing a crash with `free(): invalid pointer` whenever the method was called on my systems.