### PR TITLE
Increase promise queue size to the next power of 2

### DIFF
--- a/src/task.cpp
+++ b/src/task.cpp
@@ -372,7 +372,9 @@ void TaskManager::initThreadPool(int threadCount, int workersQueueSize)
     m_threadPool = std::make_unique<ThreadPoolX>(std::move(thread_pool));
     m_resQueue = std::make_unique<TPResQueue>(std::move(resQueue));
     m_threadPoolInputSize = maxinputSize;
-    m_promiseQueue = std::make_unique<PromiseQueue>(threadCount);
+    size_t pq_size = 2;
+    while (pq_size < threadCount) pq_size <<= 1;
+    m_promiseQueue = std::make_unique<PromiseQueue>(pq_size);
 
     LOG_PRINT_L1("Thread pool created with " << threadCount
                  << " workers with " << workersQueueSize


### PR DESCRIPTION
For some reason the `PromiseQueue` produces a fatal error if given a queue size that isn't a power of 2; passing it `std::thread::hardware_concurrency()` thus breaks graft-ng on systems with non-power-of-2 cores (e.g. on my 6c/12t machine).  It was already a reported problem on a single-core system.

This rounds the promise queue size up to the nearest power of 2.