### PR TITLE
Applied namespace graft::supernode::request to requests

### DIFF
--- a/include/requests.h
+++ b/include/requests.h
@@ -1,9 +1,9 @@
-#ifndef REQUESTS_H
-#define REQUESTS_H
+
+#pragma once
 
 #include "router.h"
 
-namespace graft {
+namespace graft::supernode::request {
 
 void registerRTARequests(graft::Router &router);
 void registerForwardRequests(graft::Router &router);
@@ -12,4 +12,3 @@ void registerDebugRequests(Router &router);
 
 }
 
-#endif // REQUESTS_H

--- a/include/rta/supernode.h
+++ b/include/rta/supernode.h
@@ -15,9 +15,11 @@ namespace cryptonote {
     class transaction;
 }
 
+namespace graft::supernode::request { struct SupernodeAnnounce; }
+
 namespace graft {
 
-struct SupernodeAnnounce;
+using graft::supernode::request::SupernodeAnnounce;
 
 /*!
  * \brief The Supernode class - Representing supernode instance
@@ -137,7 +139,7 @@ public:
      * \param announce           - reference to graft::SupernodeAnnounce
      * \return                   - true on success
      */
-    bool updateFromAnnounce(const graft::SupernodeAnnounce &announce);
+    bool updateFromAnnounce(const SupernodeAnnounce &announce);
 
     /*!
      * \brief createFromAnnounce - creates new Supernode instance from announce
@@ -147,11 +149,11 @@ public:
      * \return                   - Supernode pointer on success
      */
     static Supernode * createFromAnnounce(const std::string &path,
-                                          const graft::SupernodeAnnounce &announce,
+                                          const SupernodeAnnounce &announce,
                                           const std::string &daemon_address,
                                           bool testnet);
 
-    bool prepareAnnounce(graft::SupernodeAnnounce &announce);
+    bool prepareAnnounce(SupernodeAnnounce &announce);
 
     /*!
      * \brief exportViewkey - exports stake wallet private viewkey

--- a/include/rta/supernode.h
+++ b/include/rta/supernode.h
@@ -18,9 +18,6 @@ namespace cryptonote {
 namespace graft::supernode::request { struct SupernodeAnnounce; }
 
 namespace graft {
-
-using graft::supernode::request::SupernodeAnnounce;
-
 /*!
  * \brief The Supernode class - Representing supernode instance
  */
@@ -135,11 +132,11 @@ public:
                                        const std::string &seed_language = std::string());
 
     /*!
-     * \brief updateFromAnnounce - updates supernode from announce (helper to extract signed key images from graft::SupernodeAnnounce)
-     * \param announce           - reference to graft::SupernodeAnnounce
+     * \brief updateFromAnnounce - updates supernode from announce (helper to extract signed key images from graft::supernode::request::SupernodeAnnounce)
+     * \param announce           - reference to graft::supernode::request::SupernodeAnnounce
      * \return                   - true on success
      */
-    bool updateFromAnnounce(const SupernodeAnnounce &announce);
+    bool updateFromAnnounce(const graft::supernode::request::SupernodeAnnounce& announce);
 
     /*!
      * \brief createFromAnnounce - creates new Supernode instance from announce
@@ -149,11 +146,11 @@ public:
      * \return                   - Supernode pointer on success
      */
     static Supernode * createFromAnnounce(const std::string &path,
-                                          const SupernodeAnnounce &announce,
+                                          const graft::supernode::request::SupernodeAnnounce& announce,
                                           const std::string &daemon_address,
                                           bool testnet);
 
-    bool prepareAnnounce(SupernodeAnnounce &announce);
+    bool prepareAnnounce(graft::supernode::request::SupernodeAnnounce& announce);
 
     /*!
      * \brief exportViewkey - exports stake wallet private viewkey

--- a/include/supernode/requests/authorize_rta_tx.h
+++ b/include/supernode/requests/authorize_rta_tx.h
@@ -3,7 +3,7 @@
 
 #include "router.h"
 
-namespace graft {
+namespace graft::supernode::request {
 
 GRAFT_DEFINE_IO_STRUCT(AuthorizeRtaTxRequest,
                        (std::string, tx_hex),

--- a/include/supernode/requests/broadcast.h
+++ b/include/supernode/requests/broadcast.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-namespace graft {
+namespace graft::supernode::request {
 
 GRAFT_DEFINE_IO_STRUCT(BroadcastRequest,
                        (std::string, sender_address),

--- a/include/supernode/requests/forward.h
+++ b/include/supernode/requests/forward.h
@@ -3,15 +3,11 @@
 
 #include "router.h"
 
-namespace graft {
+namespace graft::supernode::request::walletnode {
 
 void registerForwardRequest(graft::Router& router);
 
-namespace requests::walletnode {
-
 void registerForward(graft::Router& router);
-
-}
 
 }
 

--- a/include/supernode/requests/get_info.h
+++ b/include/supernode/requests/get_info.h
@@ -4,7 +4,7 @@
 #include "router.h"
 #include "jsonrpc.h"
 
-namespace graft {
+namespace graft::supernode::request {
 
 //GRAFT_DEFINE_IO_STRUCT_INITED(GetInfoResult,
 //                              (uint64_t, alt_blocks_count, 0),

--- a/include/supernode/requests/health_check.h
+++ b/include/supernode/requests/health_check.h
@@ -3,7 +3,7 @@
 
 #include "router.h"
 
-namespace graft {
+namespace graft::supernode::request {
 
 GRAFT_DEFINE_IO_STRUCT(HealthcheckResponse,
     (std::string, NodeAccess)

--- a/include/supernode/requests/multicast.h
+++ b/include/supernode/requests/multicast.h
@@ -7,8 +7,7 @@
 #include <vector>
 #include <string>
 
-
-namespace graft {
+namespace graft::supernode::request {
 
 // Plan "B" in case we can't do that magic, we just define:
 GRAFT_DEFINE_IO_STRUCT(MulticastRequest,

--- a/include/supernode/requests/pay.h
+++ b/include/supernode/requests/pay.h
@@ -1,10 +1,10 @@
-#ifndef PAYREQUEST_H
-#define PAYREQUEST_H
+
+#pragma once
 
 #include "router.h"
 #include "jsonrpc.h"
 
-namespace graft {
+namespace graft::supernode::request {
 
 GRAFT_DEFINE_IO_STRUCT_INITED(PayRequest,
     (std::string, PaymentID, std::string()),
@@ -23,9 +23,7 @@ GRAFT_DEFINE_IO_STRUCT_INITED(PayResponse,
 
 GRAFT_DEFINE_JSON_RPC_RESPONSE_RESULT(PayResponseJsonRpc, PayResponse);
 
-
 void registerPayRequest(graft::Router &router);
 
 }
 
-#endif // PAYREQUEST_H

--- a/include/supernode/requests/pay_status.h
+++ b/include/supernode/requests/pay_status.h
@@ -1,9 +1,9 @@
-#ifndef PAYSTATUSREQUEST_H
-#define PAYSTATUSREQUEST_H
+
+#pragma once
 
 #include "router.h"
 
-namespace graft {
+namespace graft::supernode::request {
 
 GRAFT_DEFINE_IO_STRUCT(PayStatusRequest,
     (std::string, PaymentID)
@@ -17,4 +17,3 @@ void registerPayStatusRequest(graft::Router &router);
 
 }
 
-#endif // PAYSTATUSREQUEST_H

--- a/include/supernode/requests/reject_pay.h
+++ b/include/supernode/requests/reject_pay.h
@@ -1,9 +1,9 @@
-#ifndef REJECTPAYREQUEST_H
-#define REJECTPAYREQUEST_H
+
+#pragma once
 
 #include "router.h"
 
-namespace graft {
+namespace graft::supernode::request {
 
 GRAFT_DEFINE_IO_STRUCT(RejectPayRequest,
     (std::string, PaymentID)
@@ -17,4 +17,3 @@ void registerRejectPayRequest(graft::Router &router);
 
 }
 
-#endif // REJECTPAYREQUEST_H

--- a/include/supernode/requests/reject_sale.h
+++ b/include/supernode/requests/reject_sale.h
@@ -1,9 +1,9 @@
-#ifndef REJECTSALEREQUEST_H
-#define REJECTSALEREQUEST_H
+
+#pragma once
 
 #include "router.h"
 
-namespace graft {
+namespace graft::supernode::request {
 
 GRAFT_DEFINE_IO_STRUCT(RejectSaleRequest,
     (std::string, PaymentID)
@@ -17,4 +17,3 @@ void registerRejectSaleRequest(graft::Router &router);
 
 }
 
-#endif // REJECTSALEREQUEST_H

--- a/include/supernode/requests/sale.h
+++ b/include/supernode/requests/sale.h
@@ -1,12 +1,11 @@
-#ifndef SALEREQUEST_H
-#define SALEREQUEST_H
+
+#pragma once
 
 #include "router.h"
 #include "jsonrpc.h"
 #include "requestdefines.h"
 
-
-namespace graft {
+namespace graft::supernode::request {
 
 // Sale request payload
 GRAFT_DEFINE_IO_STRUCT_INITED(SaleRequest,
@@ -15,7 +14,6 @@ GRAFT_DEFINE_IO_STRUCT_INITED(SaleRequest,
     (std::string, PaymentID, std::string()),
     (uint64_t, Amount, 0)
 );
-
 
 // Sale request in wrapped as json-rpc
 GRAFT_DEFINE_JSON_RPC_REQUEST(SaleRequestJsonRpc, SaleRequest)
@@ -34,4 +32,3 @@ void registerSaleRequest(graft::Router &router);
 
 }
 
-#endif // SALEREQUEST_H

--- a/include/supernode/requests/sale_details.h
+++ b/include/supernode/requests/sale_details.h
@@ -1,13 +1,12 @@
-#ifndef SALEDETAILSREQUEST_H
-#define SALEDETAILSREQUEST_H
+
+#pragma once
 
 #include "inout.h"
 #include "router.h"
 
 #include <vector>
 
-namespace graft {
-
+namespace graft::supernode::request {
 
 // fee per supernode
 GRAFT_DEFINE_IO_STRUCT_INITED(SupernodeFee,
@@ -30,4 +29,3 @@ void registerSaleDetailsRequest(graft::Router &router);
 
 }
 
-#endif // SALEDETAILSREQUEST_H

--- a/include/supernode/requests/sale_status.h
+++ b/include/supernode/requests/sale_status.h
@@ -1,18 +1,16 @@
-#ifndef SALESTATUSREQUEST_H
-#define SALESTATUSREQUEST_H
+
+#pragma once
 
 #include "router.h"
 #include "jsonrpc.h"
 #include "rta/supernode.h"
 
-namespace graft {
+namespace graft::supernode::request {
 
 // returns sale status by sale id
 GRAFT_DEFINE_IO_STRUCT(SaleStatusRequest,
     (std::string, PaymentID)
 );
-
-
 
 // message to be broadcasted
 GRAFT_DEFINE_IO_STRUCT_INITED(UpdateSaleStatusBroadcast,
@@ -51,4 +49,3 @@ void registerSaleStatusRequest(graft::Router &router);
 
 }
 
-#endif // SALESTATUSREQUEST_H

--- a/include/supernode/requests/send_raw_tx.h
+++ b/include/supernode/requests/send_raw_tx.h
@@ -1,5 +1,5 @@
-#ifndef SENDRAWTXREQUEST_H
-#define SENDRAWTXREQUEST_H
+
+#pragma once
 
 #include "router.h"
 #include "inout.h"
@@ -8,8 +8,7 @@
 #include <string>
 #include <wallet/wallet2.h>
 
-
-namespace graft {
+namespace graft::supernode::request {
 
 // here we testing how supernode can proxy "sendrawtransaction" call to cryptonode
 
@@ -47,4 +46,3 @@ bool createSendRawTxRequest(const cryptonote::transaction &tx, SendRawTxRequest 
 
 }
 
-#endif // SENDRAWTXREQUEST_H

--- a/include/supernode/requests/send_supernode_announce.h
+++ b/include/supernode/requests/send_supernode_announce.h
@@ -1,12 +1,11 @@
-#ifndef SENDSUPERNODEANNOUNCEREQUEST_H
-#define SENDSUPERNODEANNOUNCEREQUEST_H
+
+#pragma once
 
 #include "router.h"
 #include "inout.h"
 #include "jsonrpc.h"
 
-
-namespace graft {
+namespace graft::supernode::request {
 
 GRAFT_DEFINE_IO_STRUCT(SignedKeyImageStr,
                       (std::string, key_image),
@@ -46,5 +45,4 @@ Status sendAnnounce(const graft::Router::vars_t& vars, const graft::Input& input
 
 }
 
-#endif // SENDSUPERNODEANNOUNCEREQUEST_H
 

--- a/include/supernode/requests/unicast.h
+++ b/include/supernode/requests/unicast.h
@@ -1,5 +1,5 @@
-#ifndef UNICAST_H
-#define UNICAST_H
+
+#pragma once
 
 #include "inout.h"
 #include "jsonrpc.h"
@@ -8,8 +8,7 @@
 #include <vector>
 #include <string>
 
-
-namespace graft {
+namespace graft::supernode::request {
 
 // Plan "B" in case we can't do that magic, we just define:
 GRAFT_DEFINE_IO_STRUCT_INITED(UnicastRequest,
@@ -34,8 +33,5 @@ GRAFT_DEFINE_JSON_RPC_RESPONSE_RESULT(UnicastResponseToCryptonodeJsonRpc, Unicas
 
 GRAFT_DEFINE_JSON_RPC_RESPONSE(UnicastResponseFromCryptonodeJsonRpc, UnicastResponseFromCryptonode);
 
-
 }
 
-
-#endif // UNICAST_H

--- a/src/requestdefines.cpp
+++ b/src/requestdefines.cpp
@@ -12,6 +12,7 @@
 namespace graft {
 
 using namespace std;
+using namespace graft::supernode::request;
 
 Status errorInvalidPaymentID(Output& output)
 {

--- a/src/requests.cpp
+++ b/src/requests.cpp
@@ -16,39 +16,39 @@
 #include "supernode/requests/authorize_rta_tx.h"
 #include "supernode/requests/send_supernode_announce.h"
 
-namespace graft {
+namespace graft::supernode::request::debug { void __registerDebugRequests(Router& router); }
+namespace graft::supernode::system_info { void register_request(Router& router); }
 
-void __registerDebugRequests(Router& router);
-namespace supernode::system_info { void register_request(Router& router); }
+namespace graft::supernode::request {
 
 void registerRTARequests(graft::Router &router)
 {
-    graft::registerSaleRequest(router);
-    graft::registerSaleStatusRequest(router);
-    graft::registerRejectSaleRequest(router);
-    graft::registerGetInfoRequest(router);
-    graft::registerSaleDetailsRequest(router);
-    graft::registerPayRequest(router);
-    graft::registerPayStatusRequest(router);
-    graft::registerRejectPayRequest(router);
-    graft::registerAuthorizeRtaTxRequests(router);
-    graft::registerSendSupernodeAnnounceRequest(router);
+    registerSaleRequest(router);
+    registerSaleStatusRequest(router);
+    registerRejectSaleRequest(router);
+    registerGetInfoRequest(router);
+    registerSaleDetailsRequest(router);
+    registerPayRequest(router);
+    registerPayStatusRequest(router);
+    registerRejectPayRequest(router);
+    registerAuthorizeRtaTxRequests(router);
+    registerSendSupernodeAnnounceRequest(router);
 }
 
 void registerForwardRequests(graft::Router &router)
 {
-    graft::registerForwardRequest(router);
-    graft::requests::walletnode::registerForward(router);
+    walletnode::registerForwardRequest(router);
+    walletnode::registerForward(router);
 }
 
 void registerHealthcheckRequests(Router &router)
 {
-    graft::registerHealthcheckRequest(router);
+    registerHealthcheckRequest(router);
 }
 
 void registerDebugRequests(Router &router)
 {
-    graft::__registerDebugRequests(router);
+    debug::__registerDebugRequests(router);
     graft::supernode::system_info::register_request(router);
 }
 

--- a/src/rta/supernode.cpp
+++ b/src/rta/supernode.cpp
@@ -18,6 +18,7 @@ using namespace std;
 namespace graft {
 
 using graft::supernode::request::SignedKeyImageStr;
+using graft::supernode::request::SupernodeAnnounce;
 
 Supernode::Supernode(const string &wallet_path, const string &wallet_password, const string &daemon_address, bool testnet,
                      const string &seed_language)

--- a/src/rta/supernode.cpp
+++ b/src/rta/supernode.cpp
@@ -17,6 +17,8 @@ using namespace std;
 
 namespace graft {
 
+using graft::supernode::request::SignedKeyImageStr;
+
 Supernode::Supernode(const string &wallet_path, const string &wallet_password, const string &daemon_address, bool testnet,
                      const string &seed_language)
     : m_wallet{new tools::wallet2(testnet)}

--- a/src/supernode.cpp
+++ b/src/supernode.cpp
@@ -32,6 +32,8 @@ namespace graft
 namespace snd
 {
 
+using namespace graft::supernode::request;
+
 bool Supernode::initConfigOption(int argc, const char** argv, ConfigOpts& configOpts)
 {
     bool res = GraftServer::initConfigOption(argc, argv, configOpts);
@@ -160,19 +162,19 @@ void Supernode::setHttpRouters(ConnectionManager& httpcm)
     // httpcm.addRouter(dapi_router);
 
     // Router http_router;
-    graft::registerRTARequests(dapi_router);
+    registerRTARequests(dapi_router);
     httpcm.addRouter(dapi_router);
 
     Router forward_router;
-    graft::registerForwardRequests(forward_router);
+    registerForwardRequests(forward_router);
     httpcm.addRouter(forward_router);
 
     Router health_router;
-    graft::registerHealthcheckRequests(health_router);
+    registerHealthcheckRequests(health_router);
     httpcm.addRouter(health_router);
 
     Router debug_router;
-    graft::registerDebugRequests(debug_router);
+    registerDebugRequests(debug_router);
     httpcm.addRouter(debug_router);
 }
 

--- a/src/supernode.cpp
+++ b/src/supernode.cpp
@@ -32,7 +32,6 @@ namespace graft
 namespace snd
 {
 
-using namespace graft::supernode::request;
 
 bool Supernode::initConfigOption(int argc, const char** argv, ConfigOpts& configOpts)
 {
@@ -141,7 +140,7 @@ void Supernode::startSupernodePeriodicTasks()
         size_t initial_interval_ms = 1000;
         assert(m_looper);
         m_looper->addPeriodicTask(
-                    graft::Router::Handler3(nullptr, sendAnnounce, nullptr),
+                    graft::Router::Handler3(nullptr, graft::supernode::request::sendAnnounce, nullptr),
                     std::chrono::milliseconds(m_configEx.stake_wallet_refresh_interval_ms),
                     std::chrono::milliseconds(initial_interval_ms)
                     );
@@ -150,6 +149,8 @@ void Supernode::startSupernodePeriodicTasks()
 
 void Supernode::setHttpRouters(ConnectionManager& httpcm)
 {
+    using namespace graft::supernode::request;
+
     Router dapi_router("/dapi/v2.0");
     auto http_test = [](const Router::vars_t&, const Input&, Context&, Output&)->Status
     {

--- a/src/supernode/requests/authorize_rta_tx.cpp
+++ b/src/supernode/requests/authorize_rta_tx.cpp
@@ -47,9 +47,7 @@ namespace {
     static const size_t RTA_VOTES_TO_APPROVE = 4/*7*/;
 }
 
-namespace graft {
-
-
+namespace graft::supernode::request {
 
 GRAFT_DEFINE_IO_STRUCT_INITED(SupernodeSignature,
                               (std::string, address, std::string()),
@@ -705,7 +703,6 @@ Status authorizeRtaTxResponseHandler(const Router::vars_t& vars, const graft::In
 
 }
 
-
 void registerAuthorizeRtaTxRequests(graft::Router &router)
 {
     Router::Handler3 request_handler(nullptr, authorizeRtaTxRequestHandler, nullptr);
@@ -717,3 +714,4 @@ void registerAuthorizeRtaTxRequests(graft::Router &router)
 }
 
 }
+

--- a/src/supernode/requests/debug.cpp
+++ b/src/supernode/requests/debug.cpp
@@ -19,7 +19,7 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "supernode.payrequest"
 
-namespace graft { namespace requests { namespace debug {
+namespace graft::supernode::request::debug {
 
 GRAFT_DEFINE_IO_STRUCT(DbSupernode,
     (std::string, Address),
@@ -30,9 +30,6 @@ GRAFT_DEFINE_IO_STRUCT(DbSupernode,
 GRAFT_DEFINE_IO_STRUCT(SupernodeListResponse,
     (std::vector<DbSupernode>, items)
 );
-
-
-
 
 GRAFT_DEFINE_JSON_RPC_RESPONSE_RESULT(SupernodeListJsonRpcResult, SupernodeListResponse);
 
@@ -106,11 +103,9 @@ Status doAnnounce(const Router::vars_t& vars, const graft::Input& input,
     return sendAnnounce(vars, input, ctx, output);
 }
 
-}}
-
 void __registerDebugRequests(Router &router)
 {
-#define _HANDLER(h) {nullptr, requests::debug::h, nullptr}
+#define _HANDLER(h) {nullptr, graft::supernode::request::debug::h, nullptr}
 
     router.addRoute("/debug/supernode_list", METHOD_GET, _HANDLER(getSupernodeList));
     router.addRoute("/debug/auth_sample/{height:[0-9]+}", METHOD_GET, _HANDLER(getAuthSample));
@@ -118,3 +113,4 @@ void __registerDebugRequests(Router &router)
 }
 
 }
+

--- a/src/supernode/requests/forward.cpp
+++ b/src/supernode/requests/forward.cpp
@@ -4,7 +4,7 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "supernode.forwardrequest"
 
-namespace graft { namespace requests { namespace walletnode {
+namespace graft::supernode::request::walletnode {
 
 void registerForward(Router& router)
 {
@@ -48,10 +48,6 @@ void registerForward(Router& router)
 
     router.addRoute("/walletapi/{forward:create_account|restore_account|wallet_balance|prepare_transfer|transaction_history}",METHOD_POST,{nullptr,forward,nullptr});
 }
-
-}}} //namespace graft { namespace requests { namespace walletnode {
-
-namespace graft {
 
 void registerForwardRequest(Router& router)
 {

--- a/src/supernode/requests/get_info.cpp
+++ b/src/supernode/requests/get_info.cpp
@@ -33,7 +33,7 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "supernode.getinforequest"
 
-namespace graft {
+namespace graft::supernode::request {
 
 GRAFT_DEFINE_JSON_RPC_RESPONSE(GetInfoResponseJsonRpc, GetInfoResponse);
 
@@ -104,7 +104,6 @@ Status getInfoHandler(const Router::vars_t& vars, const graft::Input& input,
         }
     }
 }
-
 
 void registerGetInfoRequest(graft::Router& router)
 {

--- a/src/supernode/requests/health_check.cpp
+++ b/src/supernode/requests/health_check.cpp
@@ -4,7 +4,7 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "supernode.healthcheckrequest"
 
-namespace graft {
+namespace graft::supernode::request {
 
 Status healthcheckHandler(const Router::vars_t& vars, const graft::Input& input,
                           graft::Context& ctx, graft::Output& output)

--- a/src/supernode/requests/pay.cpp
+++ b/src/supernode/requests/pay.cpp
@@ -1,3 +1,4 @@
+
 #include "supernode/requests/pay.h"
 #include "requestdefines.h"
 #include "requesttools.h"
@@ -17,8 +18,7 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "supernode.payrequest"
 
-namespace graft {
-
+namespace graft::supernode::request {
 
 enum class PayHandlerState : int
 {
@@ -223,3 +223,4 @@ void registerPayRequest(Router &router)
 }
 
 }
+

--- a/src/supernode/requests/pay_status.cpp
+++ b/src/supernode/requests/pay_status.cpp
@@ -7,7 +7,7 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "supernode.paystatusrequest"
 
-namespace graft {
+namespace graft::supernode::request {
 
 // json-rpc request from client
 GRAFT_DEFINE_JSON_RPC_REQUEST(PayStatusRequestJsonRpc, PayStatusRequest);

--- a/src/supernode/requests/reject_pay.cpp
+++ b/src/supernode/requests/reject_pay.cpp
@@ -5,7 +5,7 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "supernode.rejectpayrequest"
 
-namespace graft {
+namespace graft::supernode::request {
 
 Status rejectPayHandler(const Router::vars_t& vars, const graft::Input& input,
                         graft::Context& ctx, graft::Output& output)
@@ -31,3 +31,4 @@ void registerRejectPayRequest(Router &router)
 }
 
 }
+

--- a/src/supernode/requests/reject_sale.cpp
+++ b/src/supernode/requests/reject_sale.cpp
@@ -5,7 +5,7 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "supernode.rejectsalerequest"
 
-namespace graft {
+namespace graft::supernode::request {
 
 Status rejectSaleHandler(const Router::vars_t& vars, const graft::Input& input,
                          graft::Context& ctx, graft::Output& output)

--- a/src/supernode/requests/sale.cpp
+++ b/src/supernode/requests/sale.cpp
@@ -20,7 +20,7 @@ BOOST_HANA_ADAPT_STRUCT(graft::SaleData,
                         Amount
                         );
 
-namespace graft {
+namespace graft::supernode::request {
 
 static const std::chrono::seconds SALE_TTL = std::chrono::seconds(60);
 
@@ -32,16 +32,12 @@ GRAFT_DEFINE_IO_STRUCT(SaleDataMulticast,
                        (string, details)
                        );
 
-
-
-
 enum class SaleHandlerState : int
 {
     ClientRequest = 0,
     SaleMulticastReply,
     SaleStatusReply,
 };
-
 
 Status handleClientSaleRequest(const Router::vars_t& vars, const graft::Input& input, graft::Context& ctx, graft::Output& output)
 {
@@ -237,7 +233,6 @@ Status saleClientHandler(const Router::vars_t& vars, const graft::Input& input,
 Status saleCryptonodeHandler(const Router::vars_t& vars, const graft::Input& input,
                              graft::Context& ctx, graft::Output& output)
 {
-
     MulticastRequestJsonRpc req;
     if (!input.get(req)) {
         return errorInvalidParams(output);
@@ -275,7 +270,6 @@ Status saleCryptonodeHandler(const Router::vars_t& vars, const graft::Input& inp
     return Status::Ok;
 }
 
-
 void registerSaleRequest(graft::Router &router)
 {
     Router::Handler3 h1(nullptr, saleClientHandler, nullptr);
@@ -285,3 +279,4 @@ void registerSaleRequest(graft::Router &router)
 }
 
 }
+

--- a/src/supernode/requests/sale_details.cpp
+++ b/src/supernode/requests/sale_details.cpp
@@ -12,7 +12,7 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "supernode.saledetailsrequest"
 
-namespace graft {
+namespace graft::supernode::request {
 
 // json-rpc request from POS
 GRAFT_DEFINE_JSON_RPC_REQUEST(SaleDetailsRequestJsonRpc, SaleDetailsRequest);
@@ -430,3 +430,4 @@ void registerSaleDetailsRequest(Router &router)
 }
 
 }
+

--- a/src/supernode/requests/sale_status.cpp
+++ b/src/supernode/requests/sale_status.cpp
@@ -7,10 +7,9 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "supernode.salestatusrequest"
 
-namespace graft {
+namespace graft::supernode::request {
 
 using namespace std;
-
 
 // json-rpc request from client
 GRAFT_DEFINE_JSON_RPC_REQUEST(SaleStatusRequestJsonRpc, SaleStatusRequest);
@@ -134,3 +133,4 @@ bool checkSaleStatusUpdateSignature(const string &payment_id, int status, const 
 }
 
 }
+

--- a/src/supernode/requests/send_raw_tx.cpp
+++ b/src/supernode/requests/send_raw_tx.cpp
@@ -33,7 +33,7 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "supernode.sendrawtxrequest"
 
-namespace graft {
+namespace graft::supernode::request {
 
 Status sendRawTxHandler(const Router::vars_t& vars, const graft::Input& input,
                                  graft::Context& ctx, graft::Output& output)

--- a/src/supernode/requests/send_supernode_announce.cpp
+++ b/src/supernode/requests/send_supernode_announce.cpp
@@ -44,8 +44,7 @@ namespace {
 
 }
 
-
-namespace graft {
+namespace graft::supernode::request {
 
 /**
  * @brief
@@ -184,7 +183,7 @@ Status sendAnnounce(const graft::Router::vars_t& vars, const graft::Input& input
 
             supernode->setLastUpdateTime(static_cast<uint64_t>(std::time(nullptr)));
 
-            graft::SendSupernodeAnnounceJsonRpcRequest req;
+            SendSupernodeAnnounceJsonRpcRequest req;
             if (!supernode->prepareAnnounce(req.params)) {
                 return errorCustomError(string("failed to prepare announce: ") + supernode->walletAddress(),
                                         ERROR_INTERNAL_ERROR, output);

--- a/test/cryptonode_handlers_test.cpp
+++ b/test/cryptonode_handlers_test.cpp
@@ -47,6 +47,7 @@
 #include <chrono>
 
 using namespace graft;
+using namespace graft::supernode::request;
 using namespace std::chrono_literals;
 
 struct CryptonodeHandlersTest : public ::testing::Test
@@ -71,9 +72,9 @@ struct CryptonodeHandlersTest : public ::testing::Test
 
         Router router;
 
-        graft::registerGetInfoRequest(router);
-        graft::registerSendRawTxRequest(router);
-        graft::registerAuthorizeRtaTxRequests(router);
+        registerGetInfoRequest(router);
+        registerSendRawTxRequest(router);
+        registerAuthorizeRtaTxRequests(router);
 
         httpcm = std::make_unique<HttpConnectionManager>();
         httpcm->addRouter(router);

--- a/test/graft_server_test.cpp
+++ b/test/graft_server_test.cpp
@@ -19,6 +19,8 @@
 
 #include <deque>
 
+using namespace graft::supernode::request;
+
 GRAFT_DEFINE_IO_STRUCT(Payment,
       (uint64, amount),
       (uint32, block_height),
@@ -594,7 +596,7 @@ private:
             http_router.addRoute("/root/r{id:\\d+}", METHOD_GET, h3_test);
             http_router.addRoute("/root/r{id:\\d+}", METHOD_POST, h3_test);
             http_router.addRoute("/root/aaa/{s1}/bbb/{s2}", METHOD_GET, h3_test);
-            graft::registerRTARequests(http_router);
+            registerRTARequests(http_router);
         }
 
         graft::ConfigOpts copts;
@@ -1195,7 +1197,7 @@ TEST_F(GraftServerTestBase, forward)
     crypton.on_http = crypton.http_echo;
     crypton.run();
     MainServer mainServer;
-    graft::registerForwardRequests(mainServer.router);
+    registerForwardRequests(mainServer.router);
     mainServer.run();
 
     std::string post_data = "some data";
@@ -1224,7 +1226,7 @@ TEST_F(GraftServerTestBase, DISABLED_getVersion)
 {
     MainServer mainServer;
     mainServer.copts.cryptonode_rpc_address = "localhost:38281";
-    graft::registerForwardRequests(mainServer.router);
+    registerForwardRequests(mainServer.router);
     mainServer.run();
 
     graft::JsonRpcRequestHeader request;

--- a/test/rta_classes_test.cpp
+++ b/test/rta_classes_test.cpp
@@ -499,7 +499,7 @@ TEST_F(FullSupernodeListTest, announce1)
 
     FullSupernodeList fsl(daemon_addr, testnet);
 
-    SupernodeAnnounce announce;
+    graft::supernode::request::SupernodeAnnounce announce;
     ASSERT_TRUE(sn.prepareAnnounce(announce));
 
 


### PR DESCRIPTION
Applied namespace
graft::supernode:request
to all reqeusts that was moved into according place
{include,src}/supernode/requests
at previous step of planned changes.

There are a lot of things, improvements that it's worth to do. But on this step I'm was trying to do as less changes as possible.

For example if we move every request into its own space then all related structs and functions will be able to have much shorter and cleaner names. As it's already made with sys-info request and partially with debug-request.

Next is separating graft::lib and graft::supernode code.