### PR TITLE
SysInfoCounter improvement

### DIFF
--- a/include/lib/graft/connection.h
+++ b/include/lib/graft/connection.h
@@ -67,7 +67,7 @@ private:
 class Looper final : public TaskManager
 {
 public:
-    Looper(const ConfigOpts& copts);
+    Looper(const ConfigOpts& copts, SysInfoCounter* sysInfoCounter);
     virtual ~Looper();
 
     void serve();

--- a/include/lib/graft/context.h
+++ b/include/lib/graft/context.h
@@ -55,13 +55,6 @@ using SysInfoCounter = request::system_info::Counter;
 class Context
 {
 public:
-
-    const ConfigOpts& config_opts(void) const;
-    void config_opts(const ConfigOpts& copts);
-
-    SysInfoCounter& runtime_sys_info(void);
-    void runtime_sys_info(SysInfoCounter& sic);
-
     class Local
     {
     private:

--- a/include/lib/graft/handler_api.h
+++ b/include/lib/graft/handler_api.h
@@ -5,6 +5,9 @@
 namespace graft
 {
 
+namespace request::system_info { class Counter; }
+struct ConfigOpts;
+
 class HandlerAPI
 {
 public:
@@ -12,7 +15,8 @@ public:
     virtual bool addPeriodicTask(const Router::Handler& h_worker,
                                         std::chrono::milliseconds interval_ms,
                                         std::chrono::milliseconds initial_interval_ms = std::chrono::milliseconds::max()) = 0;
+    virtual request::system_info::Counter& runtimeSysInfo() = 0;
+    virtual const ConfigOpts& configOpts() const = 0;
 };
 
 }//namespace graft
-

--- a/include/lib/graft/task.h
+++ b/include/lib/graft/task.h
@@ -193,8 +193,10 @@ class ExpiringList;
 class TaskManager : private HandlerAPI
 {
 public:
-    TaskManager(const ConfigOpts& copts);
+    TaskManager(const ConfigOpts& copts, SysInfoCounter* sysInfoCounter);
     virtual ~TaskManager();
+    TaskManager(const TaskManager&) = delete;
+    TaskManager& operator = (const TaskManager&) = delete;
 
     void sendUpstream(BaseTaskPtr bt);
     void addPeriodicTask(const Router::Handler3& h3,
@@ -217,11 +219,15 @@ public:
     void onTimer(BaseTaskPtr bt);
     void onUpstreamDone(UpstreamSender& uss);
 
+    //HandlerAPI implementation
     virtual void sendUpstreamBlocking(Output& output, Input& input, std::string& err) override;
     virtual bool addPeriodicTask(const Router::Handler& h_worker,
                                  std::chrono::milliseconds interval_ms,
                                  std::chrono::milliseconds initial_interval_ms = std::chrono::milliseconds::max()) override;
+    virtual request::system_info::Counter& runtimeSysInfo() override;
+    virtual const ConfigOpts& configOpts() const override;
 
+    //
     void runWorkerActionFromTheThreadPool(BaseTaskPtr bt);
 
     virtual void notifyJobReady() = 0;
@@ -255,6 +261,7 @@ private:
 
     static inline size_t next_pow2(size_t val);
 
+    SysInfoCounter* m_sysInfoCounter;
     GlobalContextMap m_gcm;
 
     uint64_t m_cntBaseTask = 0;

--- a/include/supernode/server.h
+++ b/include/supernode/server.h
@@ -27,6 +27,11 @@ public:
         UnexpectedOk,
     };
 
+    //Call the function with derived SysInfoCounter once only if required.
+    //Otherwise, default SysInfoCounter will be created.
+    void setSysInfoCounter(std::unique_ptr<SysInfoCounter> counter);
+    SysInfoCounter& getSysInfoCounter() { return *m_sys_info.get(); }
+
     bool init(int argc, const char** argv, ConfigOpts& configOpts);
     RunRes run();
 

--- a/include/supernode/server.h
+++ b/include/supernode/server.h
@@ -30,7 +30,7 @@ public:
     //Call the function with derived SysInfoCounter once only if required.
     //Otherwise, default SysInfoCounter will be created.
     void setSysInfoCounter(std::unique_ptr<SysInfoCounter> counter);
-    SysInfoCounter& getSysInfoCounter() { return *m_sys_info.get(); }
+    SysInfoCounter& getSysInfoCounter() { return *m_sysInfo.get(); }
 
     bool init(int argc, const char** argv, ConfigOpts& configOpts);
     RunRes run();
@@ -55,8 +55,8 @@ private:
     void serve();
     static void initSignals();
     void addGlobalCtxCleaner();
-    void create_looper(ConfigOpts& configOpts);
-    void create_system_info_counter(void);
+    void createLooper(ConfigOpts& configOpts);
+    void createSystemInfoCounter(void);
     void initGraftlets();
     void initGraftletRouters();
     static void checkRoutes(graft::ConnectionManager& cm);
@@ -64,7 +64,7 @@ private:
 
     std::unique_ptr<graftlet::GraftletLoader> m_graftletLoader;
     std::map<ConnectionManager::Proto, std::unique_ptr<ConnectionManager>> m_conManagers;
-    std::unique_ptr<SysInfoCounter> m_sys_info;
+    std::unique_ptr<SysInfoCounter> m_sysInfo;
 };
 
 }//namespace graft

--- a/src/lib/graft/connection.cpp
+++ b/src/lib/graft/connection.cpp
@@ -71,7 +71,7 @@ void UpstreamSender::send(TaskManager &manager, BaseTaskPtr bt)
     m_upstream->user_data = this;
     mg_set_timer(m_upstream, mg_time() + opts.upstream_request_timeout);
 
-    auto& rsi = Context(manager.getGcm()).runtime_sys_info();
+    auto& rsi = manager.runtimeSysInfo();
     rsi.count_upstrm_http_req();
     rsi.count_upstrm_http_req_bytes_raw(url.size() + extra_headers.size() + body.size());
 }
@@ -103,7 +103,7 @@ void UpstreamSender::ev_handler(mg_connection *upstream, int ev, void *ev_data)
 
         auto* man = TaskManager::from(upstream->mgr);
         assert(man);
-        Context(man->getGcm()).runtime_sys_info().count_upstrm_http_resp_bytes_raw(hm->message.len);
+        man->runtimeSysInfo().count_upstrm_http_resp_bytes_raw(hm->message.len);
 
         setError(Status::Ok);
         upstream->flags |= MG_F_CLOSE_IMMEDIATELY;
@@ -136,8 +136,8 @@ void UpstreamSender::ev_handler(mg_connection *upstream, int ev, void *ev_data)
     }
 }
 
-Looper::Looper(const ConfigOpts& copts)
-    : TaskManager(copts)
+Looper::Looper(const ConfigOpts& copts, SysInfoCounter* sysInfoCounter)
+    : TaskManager(copts, sysInfoCounter)
     , m_mgr(std::make_unique<mg_mgr>())
 {
     mg_mgr_init(m_mgr.get(), this, cb_event);
@@ -279,13 +279,13 @@ void HttpConnectionManager::ev_handler_http(mg_connection *client, int ev, void 
     {
     case MG_EV_HTTP_REQUEST:
     {
-        Context(manager->getGcm()).runtime_sys_info().count_http_request_total();
+        manager->runtimeSysInfo().count_http_request_total();
 
         mg_set_timer(client, 0);
 
         struct http_message *hm = (struct http_message *) ev_data;
 
-        Context(manager->getGcm()).runtime_sys_info().count_http_req_bytes_raw(hm->message.len);
+        manager->runtimeSysInfo().count_http_req_bytes_raw(hm->message.len);
 
         std::string uri(hm->uri.p, hm->uri.len);
 
@@ -306,7 +306,7 @@ void HttpConnectionManager::ev_handler_http(mg_connection *client, int ev, void 
         Router::JobParams prms;
         if (httpcm->matchRoute(uri, method, prms))
         {
-            Context(manager->getGcm()).runtime_sys_info().count_http_request_routed();
+            manager->runtimeSysInfo().count_http_request_routed();
 
             mg_str& body = hm->body;
             prms.input = Input(*hm, client_host(client));
@@ -325,7 +325,7 @@ void HttpConnectionManager::ev_handler_http(mg_connection *client, int ev, void 
         }
         else
         {
-            Context(manager->getGcm()).runtime_sys_info().count_http_request_unrouted();
+            manager->runtimeSysInfo().count_http_request_unrouted();
 
             LOG_PRINT_CLN(2,client,"Matching Route not found; closing connection");
             mg_http_send_error(client, 500, "invalid parameter");
@@ -420,7 +420,7 @@ void ConnectionManager::respond(ClientTask* ct, const std::string& s)
 
     int code = 0;
     auto& ctx = ct->getCtx();
-    auto& rsi = ctx.runtime_sys_info();
+    auto& rsi = ct->getManager().runtimeSysInfo();
 
     switch(ctx.local.getLastStatus())
     {
@@ -439,7 +439,7 @@ void ConnectionManager::respond(ClientTask* ct, const std::string& s)
     {
         mg_send_head(client, code, s.size(), "Content-Type: application/json\r\nConnection: close");
         mg_send(client, s.c_str(), s.size());
-        ctx.runtime_sys_info().count_http_resp_bytes_raw(s.size());
+        rsi.count_http_resp_bytes_raw(s.size());
     }
     else
     {

--- a/src/lib/graft/context.cpp
+++ b/src/lib/graft/context.cpp
@@ -5,29 +5,5 @@
 
 namespace graft {
 
-const ConfigOpts& Context::config_opts(void) const
-{
-  const ConfigOpts* p = global.get(CONTEXT_KEY_CONFIG_OPTS, (const ConfigOpts*)nullptr);
-  assert(p);
-  return *p;
-}
-
-void Context::config_opts(const ConfigOpts& copts)
-{
-  global[CONTEXT_KEY_CONFIG_OPTS] = &copts;
-}
-
-SysInfoCounter& Context::runtime_sys_info(void)
-{
-  SysInfoCounter* c = global.get(CONTEXT_KEY_RUNTIME_SYS_INFO, (SysInfoCounter*)nullptr);
-  assert(c);
-  return *c;
-}
-
-void Context::runtime_sys_info(SysInfoCounter& sic)
-{
-  global[CONTEXT_KEY_RUNTIME_SYS_INFO] = &sic;
-}
-
 }
 

--- a/src/lib/graft/sys_info_request.cpp
+++ b/src/lib/graft/sys_info_request.cpp
@@ -19,7 +19,7 @@ using Output = graft::Output;
 
 Status handler(const Vars& vars, const Input& input, Ctx& ctx, Output& output)
 {
-    auto& rsi = ctx.runtime_sys_info();
+    auto& rsi = ctx.handlerAPI()->runtimeSysInfo();
 
     Response out;
     auto& ri = out.running_info;
@@ -46,7 +46,7 @@ Status handler(const Vars& vars, const Input& input, Ctx& ctx, Output& output)
     ri.uptime_sec = rsi.system_uptime_sec();
 
     auto& cfg = out.configuration;
-    const ConfigOpts& co = ctx.config_opts();
+    const ConfigOpts& co = ctx.handlerAPI()->configOpts();
 
     cfg.config_filename = co.config_filename;
     cfg.http_address = co.http_address;

--- a/src/supernode/server.cpp
+++ b/src/supernode/server.cpp
@@ -53,18 +53,18 @@ void GraftServer::stop(bool force)
     m_looper->stop(force);
 }
 
-void GraftServer::create_looper(ConfigOpts& configOpts)
+void GraftServer::createLooper(ConfigOpts& configOpts)
 {
     assert(!m_looper);
     m_looper = std::make_unique<Looper>(configOpts);
     assert(m_looper);
 }
 
-void GraftServer::create_system_info_counter(void)
+void GraftServer::createSystemInfoCounter(void)
 {
-    if(m_sys_info) return;
-    m_sys_info = std::make_unique<SysInfoCounter>();
-    assert(m_sys_info);
+    if(m_sysInfo) return;
+    m_sysInfo = std::make_unique<SysInfoCounter>();
+    assert(m_sysInfo);
 }
 
 void GraftServer::setSysInfoCounter(std::unique_ptr<SysInfoCounter> counter)
@@ -72,8 +72,8 @@ void GraftServer::setSysInfoCounter(std::unique_ptr<SysInfoCounter> counter)
     //Call the function with derived SysInfoCounter once only if required.
     //Otherwise, default SysInfoCounter will be created.
     //This requirement exists because it is possible that the counter to be replaced already has counted something.
-    assert(!m_sys_info);
-    m_sys_info.swap(counter);
+    assert(!m_sysInfo);
+    m_sysInfo.swap(counter);
 }
 
 void GraftServer::getThreadPoolInfo(uint64_t& activeWorkers, uint64_t& expelledWorkers) const
@@ -129,8 +129,8 @@ void GraftServer::initGlobalContext()
 //    ctx.global["testnet"] = copts.testnet;
 //    ctx.global["watchonly_wallets_path"] = copts.watchonly_wallets_path;
 //    ctx.global["cryptonode_rpc_address"] = copts.cryptonode_rpc_address;
-    assert(m_sys_info);
-    ctx.runtime_sys_info(*(m_sys_info.get()));
+    assert(m_sysInfo);
+    ctx.runtime_sys_info(*(m_sysInfo.get()));
     ctx.config_opts(getCopts());
 }
 
@@ -162,12 +162,12 @@ void GraftServer::addGenericCallbackRoute()
 
 bool GraftServer::init(int argc, const char** argv, ConfigOpts& configOpts)
 {
-    create_system_info_counter();
+    createSystemInfoCounter();
 
     bool res = initConfigOption(argc, argv, configOpts);
     if(!res) return false;
 
-    create_looper(configOpts);
+    createLooper(configOpts);
     initGraftlets();
     addGlobalCtxCleaner();
 

--- a/src/supernode/server.cpp
+++ b/src/supernode/server.cpp
@@ -62,9 +62,18 @@ void GraftServer::create_looper(ConfigOpts& configOpts)
 
 void GraftServer::create_system_info_counter(void)
 {
-    assert(!m_sys_info);
+    if(m_sys_info) return;
     m_sys_info = std::make_unique<SysInfoCounter>();
     assert(m_sys_info);
+}
+
+void GraftServer::setSysInfoCounter(std::unique_ptr<SysInfoCounter> counter)
+{
+    //Call the function with derived SysInfoCounter once only if required.
+    //Otherwise, default SysInfoCounter will be created.
+    //This requirement exists because it is possible that the counter to be replaced already has counted something.
+    assert(!m_sys_info);
+    m_sys_info.swap(counter);
 }
 
 void GraftServer::getThreadPoolInfo(uint64_t& activeWorkers, uint64_t& expelledWorkers) const
@@ -153,11 +162,12 @@ void GraftServer::addGenericCallbackRoute()
 
 bool GraftServer::init(int argc, const char** argv, ConfigOpts& configOpts)
 {
+    create_system_info_counter();
+
     bool res = initConfigOption(argc, argv, configOpts);
     if(!res) return false;
 
     create_looper(configOpts);
-    create_system_info_counter();
     initGraftlets();
     addGlobalCtxCleaner();
 


### PR DESCRIPTION
- SysInfoCounter can be extended by inheritance.

- SysInfoCounter can be accessed from HandlerAPI or directly, instead of global Context