### PR TITLE
Rewrote and optimized supernode selection code

### DIFF
--- a/include/rta/fullsupernodelist.h
+++ b/include/rta/fullsupernodelist.h
@@ -24,10 +24,11 @@ namespace utils {
 class FullSupernodeList
 {
 public:
-    static const uint8_t  AUTH_SAMPLE_SIZE = 4;
-    static const size_t   ITEMS_PER_TIER = 1;
-    static const uint64_t AUTH_SAMPLE_HASH_HEIGHT = 20; // block number for calculating auth sample should be calculated as current block height - AUTH_SAMPLE_HASH_HEIGHT;
-    static const uint64_t ANNOUNCE_TTL_SECONDS = 60 * 60; // if more than ANNOUNCE_TTL_SECONDS passed from last annouce - supernode excluded from auth sample selection
+    static constexpr int32_t TIERS = 4;
+    static constexpr int32_t ITEMS_PER_TIER = 1;
+    static constexpr int32_t AUTH_SAMPLE_SIZE = TIERS * ITEMS_PER_TIER;
+    static constexpr int64_t AUTH_SAMPLE_HASH_HEIGHT = 20; // block number for calculating auth sample should be calculated as current block height - AUTH_SAMPLE_HASH_HEIGHT;
+    static constexpr int64_t ANNOUNCE_TTL_SECONDS = 60 * 60; // if more than ANNOUNCE_TTL_SECONDS passed from last annouce - supernode excluded from auth sample selection
 
     FullSupernodeList(const std::string &daemon_address, bool testnet = false);
     ~FullSupernodeList();
@@ -127,11 +128,6 @@ public:
 
 
 private:
-    void selectTierSupernodes(const crypto::hash &block_hash, uint64_t tier_min_stake, uint64_t tier_max_stake,
-                              std::vector<SupernodePtr> &output, const std::vector<SupernodePtr> &selected_items,
-                              size_t max_items);
-    bool bestSupernode(std::vector<SupernodePtr> &arg, const crypto::hash &block_hash, SupernodePtr &result);
-
     bool loadWallet(const std::string &wallet_path);
 
 private:

--- a/include/rta/supernode.h
+++ b/include/rta/supernode.h
@@ -31,10 +31,10 @@ public:
     //  90,000 GRFT –  tier 2
     //  150,000 GRFT – tier 3
     //  250,000 GRFT – tier 4
-    static const uint64_t TIER1_STAKE_AMOUNT = COIN *  50000;
-    static const uint64_t TIER2_STAKE_AMOUNT = COIN *  90000;
-    static const uint64_t TIER3_STAKE_AMOUNT = COIN * 150000;
-    static const uint64_t TIER4_STAKE_AMOUNT = COIN * 250000;
+    static constexpr uint64_t TIER1_STAKE_AMOUNT = COIN *  50000;
+    static constexpr uint64_t TIER2_STAKE_AMOUNT = COIN *  90000;
+    static constexpr uint64_t TIER3_STAKE_AMOUNT = COIN * 150000;
+    static constexpr uint64_t TIER4_STAKE_AMOUNT = COIN * 250000;
 
     /*!
      * \brief Supernode - constructs supernode
@@ -73,6 +73,11 @@ public:
      * \return            - stake amount in atomic units
      */
     uint64_t stakeAmount() const;
+    /*!
+     * \brief tier - returns the tier of this supernode based on its stake amount
+     * \return     - the tier (1-4) of the supernode or 0 if the verified stake amount is below tier 1
+     */
+    uint32_t tier() const;
     /*!
      * \brief walletBalance - returns wallet balance as seen by the internal wallet; note that this
      *                        can be wrong for a view-only wallet with unverified transactions: you
@@ -222,13 +227,13 @@ public:
      * \brief lastUpdateTime - returns timestamp when supernode updated last time
      * \return
      */
-    uint64_t lastUpdateTime() const;
+    int64_t lastUpdateTime() const;
 
     /*!
      * \brief setLastUpdateTime - upda
      * \param time
      */
-    void setLastUpdateTime(uint64_t time);
+    void setLastUpdateTime(int64_t time);
 
 private:
     Supernode(bool testnet = false);
@@ -237,7 +242,7 @@ private:
     using wallet2_ptr = boost::scoped_ptr<tools::wallet2>;
     mutable wallet2_ptr m_wallet;
     std::string    m_network_address;
-    uint64_t       m_last_update_time;
+    int64_t        m_last_update_time;
 };
 
 using SupernodePtr = boost::shared_ptr<Supernode>;

--- a/src/requests/sendsupernodeannouncerequest.cpp
+++ b/src/requests/sendsupernodeannouncerequest.cpp
@@ -182,7 +182,7 @@ Status sendAnnounce(const graft::Router::vars_t& vars, const graft::Input& input
                                         ERROR_INTERNAL_ERROR, output);
             }
 
-            supernode->setLastUpdateTime(static_cast<uint64_t>(std::time(nullptr)));
+            supernode->setLastUpdateTime(static_cast<int64_t>(std::time(nullptr)));
 
             graft::SendSupernodeAnnounceJsonRpcRequest req;
             if (!supernode->prepareAnnounce(req.params)) {

--- a/src/rta/supernode.cpp
+++ b/src/rta/supernode.cpp
@@ -17,6 +17,10 @@ using namespace std;
 
 namespace graft {
 
+#ifndef __cpp_inline_variables
+constexpr uint64_t Supernode::TIER1_STAKE_AMOUNT, Supernode::TIER2_STAKE_AMOUNT, Supernode::TIER3_STAKE_AMOUNT, Supernode::TIER4_STAKE_AMOUNT;
+#endif
+
 Supernode::Supernode(const string &wallet_path, const string &wallet_password, const string &daemon_address, bool testnet,
                      const string &seed_language)
     : m_wallet{new tools::wallet2(testnet)}
@@ -54,6 +58,16 @@ Supernode::~Supernode()
 uint64_t Supernode::stakeAmount() const
 {
     return m_wallet->unspent_balance();
+}
+
+uint32_t Supernode::tier() const
+{
+    auto stake = stakeAmount();
+    return 0 +
+        (stake >= TIER1_STAKE_AMOUNT) +
+        (stake >= TIER2_STAKE_AMOUNT) +
+        (stake >= TIER3_STAKE_AMOUNT) +
+        (stake >= TIER4_STAKE_AMOUNT);
 }
 
 uint64_t Supernode::walletBalance() const
@@ -364,12 +378,12 @@ bool Supernode::validateAddress(const string &address, bool testnet)
     return address.size() > 0 && cryptonote::get_account_address_from_str(acc, testnet, address);
 }
 
-uint64_t Supernode::lastUpdateTime() const
+int64_t Supernode::lastUpdateTime() const
 {
     return m_last_update_time;
 }
 
-void Supernode::setLastUpdateTime(uint64_t time)
+void Supernode::setLastUpdateTime(int64_t time)
 {
     m_last_update_time = time;
 }


### PR DESCRIPTION
The previous solution was needlessly complicated and difficult to follow.

This proposed new implementation figures out how many SNs are needed on each tier; if some tiers are lacking the required number it selects additional SNs from the highest available tier with surplus SNs.  (This is a slightly change from the previous logic which would end replacing missing T4s with T1s).

Conceptually and in terms of code this is much simpler: the algorithm simply selects a calculated number from each tier; the old code needed to keep track of which wallets had already been selected to avoid re-selecting them (doing a relatively expensive linear scan when considering each potentially admissable supernode).

The new algorithm copies and divides all supernodes into tiers in one (mutex-locked) pass from the available supernode list.  The previous code required at least 4 and up to 64 passes through the supernode list, each pass itself requiring a mutex lock.

A more efficient max-elements algorithm is used (using a single `std::partial_sort` per tier rather than `std::max_element` multiple times).

This commit also ends up fixing a potential issue where a supernode that has never announced could be included in the auth sample (because of an unsigned overflow in the seconds-since-announce calculation when the last announce time equals 0).