### PR TITLE
Stake transaction validation on supernode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,7 @@ add_library(supernode_common STATIC
     ${PROJECT_SOURCE_DIR}/src/supernode/requests/sale_status.cpp
     ${PROJECT_SOURCE_DIR}/src/supernode/requests/send_raw_tx.cpp
     ${PROJECT_SOURCE_DIR}/src/supernode/requests/send_supernode_announce.cpp
+    ${PROJECT_SOURCE_DIR}/src/supernode/requests/send_supernode_stake_txs.cpp
     ${PROJECT_SOURCE_DIR}/src/supernode/requests/send_transfer.cpp
     ${PROJECT_SOURCE_DIR}/src/rta/DaemonRpcClient.cpp
     ${PROJECT_SOURCE_DIR}/src/rta/fullsupernodelist.cpp

--- a/include/rta/DaemonRpcClient.h
+++ b/include/rta/DaemonRpcClient.h
@@ -51,6 +51,7 @@ public:
     bool get_tx(const std::string &hash_str, cryptonote::transaction &out_tx, uint64_t &block_num, bool &mined);
     bool get_height(uint64_t &height);
     bool get_block_hash(uint64_t height, std::string &hash);
+    bool send_supernode_stake_txs();
 
 protected:
     bool init(const std::string &daemon_address, boost::optional<epee::net_utils::http::login> daemon_login);

--- a/include/rta/DaemonRpcClient.h
+++ b/include/rta/DaemonRpcClient.h
@@ -51,7 +51,7 @@ public:
     bool get_tx(const std::string &hash_str, cryptonote::transaction &out_tx, uint64_t &block_num, bool &mined);
     bool get_height(uint64_t &height);
     bool get_block_hash(uint64_t height, std::string &hash);
-    bool send_supernode_stake_txs();
+    bool send_supernode_stake_txs(const char* network_address, const char* address);
 
 protected:
     bool init(const std::string &daemon_address, boost::optional<epee::net_utils::http::login> daemon_login);

--- a/include/rta/fullsupernodelist.h
+++ b/include/rta/fullsupernodelist.h
@@ -143,6 +143,12 @@ public:
      */
     void updateStakeTransactions(const stake_transaction_array& stake_txs);
 
+    /*!
+     * \brief refreshedStakeTransactions - request stake transactions from cryptonode
+     * \return
+     */
+    void refreshStakeTransactions(const char* supernode_network_address, const char* supernode_address);
+
 private:
     bool loadWallet(const std::string &wallet_path);
 

--- a/include/rta/fullsupernodelist.h
+++ b/include/rta/fullsupernodelist.h
@@ -126,6 +126,23 @@ public:
      */
     size_t refreshedItems() const;
 
+    struct stake_transaction
+    {
+      uint64_t amount = 0;
+      uint64_t block_height = 0;
+      uint64_t unlock_time = 0;
+      std::string supernode_public_id;
+      std::string supernode_public_address;
+      std::string supernode_signature;
+    };
+    typedef std::vector<stake_transaction> stake_transaction_array;
+
+    /*!
+     * \brief updateStakeTransactions - update stake transactions
+     * \param                         - array of stake transactions
+     * \return
+     */
+    void updateStakeTransactions(const stake_transaction_array& stake_txs);
 
 private:
     bool loadWallet(const std::string &wallet_path);

--- a/include/rta/fullsupernodelist.h
+++ b/include/rta/fullsupernodelist.h
@@ -133,7 +133,6 @@ public:
       uint64_t unlock_time = 0;
       std::string supernode_public_id;
       std::string supernode_public_address;
-      std::string supernode_signature;
     };
     typedef std::vector<stake_transaction> stake_transaction_array;
 

--- a/include/rta/supernode.h
+++ b/include/rta/supernode.h
@@ -3,6 +3,7 @@
 
 #include <crypto/crypto.h>
 #include <cryptonote_config.h>
+#include <cryptonote_core/stake_transaction_processor.h>
 #include <boost/scoped_ptr.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/asio/io_service.hpp>
@@ -28,14 +29,10 @@ class Supernode
 public:
     using SignedKeyImage = std::pair<crypto::key_image, crypto::signature>;
 
-    //  50,000 GRFT –  tier 1
-    //  90,000 GRFT –  tier 2
-    //  150,000 GRFT – tier 3
-    //  250,000 GRFT – tier 4
-    static constexpr uint64_t TIER1_STAKE_AMOUNT = COIN *  50000;
-    static constexpr uint64_t TIER2_STAKE_AMOUNT = COIN *  90000;
-    static constexpr uint64_t TIER3_STAKE_AMOUNT = COIN * 150000;
-    static constexpr uint64_t TIER4_STAKE_AMOUNT = COIN * 250000;
+    static constexpr uint64_t TIER1_STAKE_AMOUNT = cryptonote::StakeTransactionProcessor::TIER1_STAKE_AMOUNT;
+    static constexpr uint64_t TIER2_STAKE_AMOUNT = cryptonote::StakeTransactionProcessor::TIER1_STAKE_AMOUNT;
+    static constexpr uint64_t TIER3_STAKE_AMOUNT = cryptonote::StakeTransactionProcessor::TIER1_STAKE_AMOUNT;
+    static constexpr uint64_t TIER4_STAKE_AMOUNT = cryptonote::StakeTransactionProcessor::TIER1_STAKE_AMOUNT;
 
     /*!
      * \brief Supernode - constructs supernode
@@ -74,6 +71,13 @@ public:
      * \return            - stake amount in atomic units
      */
     uint64_t stakeAmount() const;
+
+    /*!
+     * \brief setStakeAmount - set stake amount
+     * \param                - amount
+     */
+    void setStakeAmount(uint64_t amount);
+
     /*!
      * \brief tier - returns the tier of this supernode based on its stake amount
      * \return     - the tier (1-4) of the supernode or 0 if the verified stake amount is below tier 1
@@ -278,6 +282,7 @@ private:
     std::atomic<int64_t>       m_last_update_time;
     mutable boost::shared_mutex m_wallet_guard;
 
+    std::atomic<uint64_t> m_stake_amount;
     std::atomic<uint64_t> m_stake_transaction_block_height;
     std::atomic<uint64_t> m_stake_transaction_unlock_time;
 };

--- a/include/rta/supernode.h
+++ b/include/rta/supernode.h
@@ -3,7 +3,7 @@
 
 #include <crypto/crypto.h>
 #include <cryptonote_config.h>
-#include <cryptonote_core/stake_transaction_processor.h>
+#include <graft_rta_config.h>
 #include <boost/scoped_ptr.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/asio/io_service.hpp>
@@ -29,10 +29,10 @@ class Supernode
 public:
     using SignedKeyImage = std::pair<crypto::key_image, crypto::signature>;
 
-    static constexpr uint64_t TIER1_STAKE_AMOUNT = cryptonote::StakeTransactionProcessor::TIER1_STAKE_AMOUNT;
-    static constexpr uint64_t TIER2_STAKE_AMOUNT = cryptonote::StakeTransactionProcessor::TIER1_STAKE_AMOUNT;
-    static constexpr uint64_t TIER3_STAKE_AMOUNT = cryptonote::StakeTransactionProcessor::TIER1_STAKE_AMOUNT;
-    static constexpr uint64_t TIER4_STAKE_AMOUNT = cryptonote::StakeTransactionProcessor::TIER1_STAKE_AMOUNT;
+    static constexpr uint64_t TIER1_STAKE_AMOUNT = config::graft::TIER1_STAKE_AMOUNT;
+    static constexpr uint64_t TIER2_STAKE_AMOUNT = config::graft::TIER2_STAKE_AMOUNT;
+    static constexpr uint64_t TIER3_STAKE_AMOUNT = config::graft::TIER3_STAKE_AMOUNT;
+    static constexpr uint64_t TIER4_STAKE_AMOUNT = config::graft::TIER4_STAKE_AMOUNT;
 
     /*!
      * \brief Supernode - constructs supernode

--- a/include/rta/supernode.h
+++ b/include/rta/supernode.h
@@ -242,6 +242,29 @@ public:
      */
     bool busy() const;
 
+    /*!
+     * \brief stakeTransactionBlockHeight - height of block for stake transaction
+     * \return                            - height of block
+     */
+    uint64_t stakeTransactionBlockHeight() const;
+
+    /*!
+     * \brief setStakeTransactionBlock - set height of block for stake transaction
+     * \param                          - height of block
+     */
+    void setStakeTransactionBlockHeight(uint64_t blockHeight);
+
+    /*!
+     * \brief stakeTransactionUnlockTime - number of blocks for unlocking stake transaction
+     * \return
+     */
+    uint64_t stakeTransactionUnlockTime() const;
+
+    /*!
+     * \brief setStakeTransactionUnlockTime - set number of blocks for unlocking stake transaction
+     * \param                          - height of block
+     */
+    void setStakeTransactionUnlockTime(uint64_t unlockTime);
 
 private:
     Supernode(bool testnet = false);
@@ -255,6 +278,8 @@ private:
     std::atomic<int64_t>       m_last_update_time;
     mutable boost::shared_mutex m_wallet_guard;
 
+    std::atomic<uint64_t> m_stake_transaction_block_height;
+    std::atomic<uint64_t> m_stake_transaction_unlock_time;
 };
 
 using SupernodePtr = boost::shared_ptr<Supernode>;

--- a/include/supernode/requests/send_supernode_stake_txs.h
+++ b/include/supernode/requests/send_supernode_stake_txs.h
@@ -8,6 +8,8 @@ namespace graft::supernode::request {
 
 GRAFT_DEFINE_IO_STRUCT_INITED(SupernodeStakeTransaction,
                               (std::string, hash, std::string()),
+                              (uint64_t, amount, 0),
+                              (uint32_t, tier, 0),
                               (uint64_t, block_height, 0),
                               (uint64_t, unlock_time, 0),
                               (std::string, supernode_public_id, std::string()),

--- a/include/supernode/requests/send_supernode_stake_txs.h
+++ b/include/supernode/requests/send_supernode_stake_txs.h
@@ -14,8 +14,7 @@ GRAFT_DEFINE_IO_STRUCT_INITED(SupernodeStakeTransaction,
                               (uint64_t, unlock_time, 0),
                               (std::string, supernode_public_id, std::string()),
                               (std::string, supernode_public_address, std::string()),
-                              (std::string, supernode_signature, std::string()),
-                              (std::string, tx_secret_key, std::string())
+                              (std::string, supernode_signature, std::string())
                        );
 
 GRAFT_DEFINE_IO_STRUCT_INITED(SupernodeStakeTransactions,

--- a/include/supernode/requests/send_supernode_stake_txs.h
+++ b/include/supernode/requests/send_supernode_stake_txs.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "lib/graft/router.h"
+#include "lib/graft/inout.h"
+#include "lib/graft/jsonrpc.h"
+
+namespace graft::supernode::request {
+
+GRAFT_DEFINE_IO_STRUCT_INITED(SupernodeStakeTransaction,
+                              (std::string, hash, std::string()),
+                              (uint64_t, block_height, 0),
+                              (uint64_t, unlock_time, 0),
+                              (std::string, supernode_public_id, std::string()),
+                              (std::string, supernode_public_address, std::string()),
+                              (std::string, tx_secret_key, std::string())
+                       );
+
+GRAFT_DEFINE_IO_STRUCT_INITED(SupernodeStakeTransactions,
+                              (std::vector<SupernodeStakeTransaction>, stake_txs, std::vector<SupernodeStakeTransaction>())
+                       );
+
+GRAFT_DEFINE_IO_STRUCT_INITED(SendSupernodeStakeTransactionsResponse,
+                              (int, Status, 0)
+                              );
+
+GRAFT_DEFINE_JSON_RPC_REQUEST(SendSupernodeStakeTransactionsJsonRpcRequest, SupernodeStakeTransactions);
+GRAFT_DEFINE_JSON_RPC_RESPONSE_RESULT(SendSupernodeStakeTransactionsJsonRpcResponse, SendSupernodeStakeTransactionsResponse);
+
+void registerSendSupernodeStakeTransactionsRequest(graft::Router &router);
+
+}

--- a/include/supernode/requests/send_supernode_stake_txs.h
+++ b/include/supernode/requests/send_supernode_stake_txs.h
@@ -12,6 +12,7 @@ GRAFT_DEFINE_IO_STRUCT_INITED(SupernodeStakeTransaction,
                               (uint64_t, unlock_time, 0),
                               (std::string, supernode_public_id, std::string()),
                               (std::string, supernode_public_address, std::string()),
+                              (std::string, supernode_signature, std::string()),
                               (std::string, tx_secret_key, std::string())
                        );
 

--- a/include/supernode/requests/send_supernode_stake_txs.h
+++ b/include/supernode/requests/send_supernode_stake_txs.h
@@ -21,7 +21,7 @@ GRAFT_DEFINE_IO_STRUCT_INITED(SupernodeStakeTransactions,
                        );
 
 GRAFT_DEFINE_IO_STRUCT_INITED(SendSupernodeStakeTransactionsResponse,
-                              (int, Status, 0)
+                              (int, status, 0)
                               );
 
 GRAFT_DEFINE_JSON_RPC_REQUEST(SendSupernodeStakeTransactionsJsonRpcRequest, SupernodeStakeTransactions);

--- a/include/supernode/requests/send_supernode_stake_txs.h
+++ b/include/supernode/requests/send_supernode_stake_txs.h
@@ -13,8 +13,7 @@ GRAFT_DEFINE_IO_STRUCT_INITED(SupernodeStakeTransaction,
                               (uint64_t, block_height, 0),
                               (uint64_t, unlock_time, 0),
                               (std::string, supernode_public_id, std::string()),
-                              (std::string, supernode_public_address, std::string()),
-                              (std::string, supernode_signature, std::string())
+                              (std::string, supernode_public_address, std::string())
                        );
 
 GRAFT_DEFINE_IO_STRUCT_INITED(SupernodeStakeTransactions,

--- a/include/supernode/supernode.h
+++ b/include/supernode/supernode.h
@@ -26,6 +26,7 @@ class Supernode : public GraftServer
     void setHttpRouters(ConnectionManager& httpcm);
     void setCoapRouters(ConnectionManager& coapcm);
     void loadStakeWallets();
+    void requestStakeTransactions();
 
     ConfigOptsEx m_configEx;
 protected:

--- a/src/rta/DaemonRpcClient.cpp
+++ b/src/rta/DaemonRpcClient.cpp
@@ -172,16 +172,18 @@ bool DaemonRpcClient::get_block_hash(uint64_t height, string &hash)
     return true;
 }
 
-bool DaemonRpcClient::send_supernode_stake_txs()
+bool DaemonRpcClient::send_supernode_stake_txs(const char* network_address, const char* address)
 {
     epee::json_rpc::request<cryptonote::COMMAND_RPC_SUPERNODE_GET_STAKE_TRANSACTIONS::request> req = AUTO_VAL_INIT(req);
     epee::json_rpc::response<cryptonote::COMMAND_RPC_SUPERNODE_GET_STAKE_TRANSACTIONS::response, std::string> res = AUTO_VAL_INIT(res);
     req.jsonrpc = "2.0";
     req.id = epee::serialization::storage_entry(0);
     req.method = "send_supernode_stake_txs";
+    req.params.network_address = network_address;
+    req.params.address = address;
     bool r = epee::net_utils::invoke_http_json("/json_rpc/rta", req, res, m_http_client, m_rpc_timeout);
     if (!r) {
-        LOG_ERROR("/rta/send_supernode_stake_txs error");
+        LOG_ERROR("/json_rpc/rta/send_supernode_stake_txs error");
         return false;
     }
 

--- a/src/rta/DaemonRpcClient.cpp
+++ b/src/rta/DaemonRpcClient.cpp
@@ -172,6 +172,22 @@ bool DaemonRpcClient::get_block_hash(uint64_t height, string &hash)
     return true;
 }
 
+bool DaemonRpcClient::send_supernode_stake_txs()
+{
+    epee::json_rpc::request<cryptonote::COMMAND_RPC_SUPERNODE_GET_STAKE_TRANSACTIONS::request> req = AUTO_VAL_INIT(req);
+    epee::json_rpc::response<cryptonote::COMMAND_RPC_SUPERNODE_GET_STAKE_TRANSACTIONS::response, std::string> res = AUTO_VAL_INIT(res);
+    req.jsonrpc = "2.0";
+    req.id = epee::serialization::storage_entry(0);
+    req.method = "send_supernode_stake_txs";
+    bool r = epee::net_utils::invoke_http_json("/json_rpc/rta", req, res, m_http_client, m_rpc_timeout);
+    if (!r) {
+        LOG_ERROR("/rta/send_supernode_stake_txs error");
+        return false;
+    }
+
+    return true;
+}
+
 bool DaemonRpcClient::init(const string &daemon_address, boost::optional<epee::net_utils::http::login> daemon_login)
 {
     return m_http_client.set_server(daemon_address, daemon_login);

--- a/src/rta/fullsupernodelist.cpp
+++ b/src/rta/fullsupernodelist.cpp
@@ -130,8 +130,6 @@ FullSupernodeList::FullSupernodeList(const string &daemon_address, bool testnet)
     , m_tp(new utils::ThreadPool())
 {
     m_refresh_counter = 0;
-
-    m_rpc_client.send_supernode_stake_txs();
 }
 
 FullSupernodeList::~FullSupernodeList()
@@ -403,6 +401,11 @@ void FullSupernodeList::updateStakeTransactions(const stake_transaction_array& s
         sn->setStakeTransactionBlockHeight(tx.block_height);
         sn->setStakeTransactionUnlockTime(tx.unlock_time);
     }
+}
+
+void FullSupernodeList::refreshStakeTransactions(const char* network_address, const char* address)
+{
+    m_rpc_client.send_supernode_stake_txs(network_address, address);
 }
 
 std::ostream& operator<<(std::ostream& os, const std::vector<SupernodePtr> supernodes)

--- a/src/rta/fullsupernodelist.cpp
+++ b/src/rta/fullsupernodelist.cpp
@@ -130,6 +130,8 @@ FullSupernodeList::FullSupernodeList(const string &daemon_address, bool testnet)
     , m_tp(new utils::ThreadPool())
 {
     m_refresh_counter = 0;
+
+    m_rpc_client.send_supernode_stake_txs();
 }
 
 FullSupernodeList::~FullSupernodeList()

--- a/src/rta/fullsupernodelist.cpp
+++ b/src/rta/fullsupernodelist.cpp
@@ -372,6 +372,72 @@ bool FullSupernodeList::loadWallet(const std::string &wallet_path)
     return result;
 }
 
+namespace
+{
+
+bool verifySignature(const std::string& id_key, const std::string& wallet_public_address, const std::string& signature)
+{
+    crypto::public_key W;
+    if (!epee::string_tools::hex_to_pod(id_key, W))
+    {
+        LOG_ERROR("Invalid supernode public identifier '" << id_key << "'");
+        return false;
+    }
+
+    crypto::signature sign;
+    if (!epee::string_tools::hex_to_pod(signature, sign))
+    {
+        LOG_ERROR("Invalid supernode signature '" << signature << "'");
+        return false;
+    }
+
+    std::string data = wallet_public_address + ":" + id_key;
+    crypto::hash hash;
+    crypto::cn_fast_hash(data.data(), data.size(), hash);
+    return crypto::check_signature(hash, W, sign);
+}
+
+}
+
+void FullSupernodeList::updateStakeTransactions(const stake_transaction_array& stake_txs)
+{
+    boost::unique_lock<boost::shared_mutex> writerLock(m_access);
+
+      //reset current stake transactions state
+
+    for (const std::unordered_map<std::string, SupernodePtr>::value_type& sn_desc : m_list)
+    {
+        SupernodePtr sn = sn_desc.second;
+
+        if (!sn)
+            continue;
+
+        sn->setStakeAmount(0);
+        sn->setStakeTransactionBlockHeight(0);
+        sn->setStakeTransactionUnlockTime(0);
+    }
+
+      //apply new stake transactions state
+
+    for (const stake_transaction& tx : stake_txs)
+    {
+        SupernodePtr sn = get(tx.supernode_public_address);
+
+        if (!sn)
+            continue;
+
+        if (!verifySignature(tx.supernode_public_id, tx.supernode_public_address, tx.supernode_signature))
+        {
+            LOG_ERROR("Supernode signature failed for supernode_public_id='" << tx.supernode_public_id << "', supernode_public_address='" <<
+                tx.supernode_public_address << "', signature='" << tx.supernode_signature << "'");
+            continue;
+        }
+
+        sn->setStakeAmount(tx.amount);
+        sn->setStakeTransactionBlockHeight(tx.block_height);
+        sn->setStakeTransactionUnlockTime(tx.unlock_time);
+    }
+}
 
 std::ostream& operator<<(std::ostream& os, const std::vector<SupernodePtr> supernodes)
 {

--- a/src/rta/supernode.cpp
+++ b/src/rta/supernode.cpp
@@ -80,8 +80,12 @@ Supernode::~Supernode()
 
 uint64_t Supernode::stakeAmount() const
 {
-    boost::shared_lock<boost::shared_mutex> readLock(m_wallet_guard);
-    return m_wallet->unspent_balance();
+    return m_stake_amount;
+}
+
+void Supernode::setStakeAmount(uint64_t amount)
+{
+    m_stake_amount = amount;
 }
 
 uint32_t Supernode::tier() const

--- a/src/rta/supernode.cpp
+++ b/src/rta/supernode.cpp
@@ -449,8 +449,30 @@ bool Supernode::busy() const
     }
 }
 
+uint64_t Supernode::stakeTransactionBlockHeight() const
+{
+    return m_stake_transaction_block_height;
+}
+
+void Supernode::setStakeTransactionBlockHeight(uint64_t blockHeight)
+{
+    m_stake_transaction_block_height.store(blockHeight);
+}
+
+uint64_t Supernode::stakeTransactionUnlockTime() const
+{
+    return m_stake_transaction_unlock_time;
+}
+
+void Supernode::setStakeTransactionUnlockTime(uint64_t unlockTime)
+{
+    m_stake_transaction_unlock_time.store(unlockTime);
+}
+
 Supernode::Supernode(bool testnet)
 : m_wallet{ new tools::wallet2(testnet) }
+, m_stake_transaction_block_height()
+, m_stake_transaction_unlock_time()
 {
 
 }

--- a/src/supernode/requests.cpp
+++ b/src/supernode/requests.cpp
@@ -15,6 +15,7 @@
 #include "supernode/requests/send_raw_tx.h"
 #include "supernode/requests/authorize_rta_tx.h"
 #include "supernode/requests/send_supernode_announce.h"
+#include "supernode/requests/send_supernode_stake_txs.h"
 
 namespace graft::supernode::request::debug { void __registerDebugRequests(Router& router); }
 namespace graft::request::system_info { void register_request(Router& router); }
@@ -33,6 +34,7 @@ void registerRTARequests(graft::Router &router)
     registerRejectPayRequest(router);
     registerAuthorizeRtaTxRequests(router);
     registerSendSupernodeAnnounceRequest(router);
+    registerSendSupernodeStakeTransactionsRequest(router);
 }
 
 void registerWalletApiRequests(graft::Router &router)

--- a/src/supernode/requests/send_supernode_stake_txs.cpp
+++ b/src/supernode/requests/send_supernode_stake_txs.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) 2018, The Graft Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "supernode/requests/send_supernode_stake_txs.h"
+#include "supernode/requestdefines.h"
+#include "rta/fullsupernodelist.h"
+#include "rta/supernode.h"
+
+#include <misc_log_ex.h>
+#include <boost/shared_ptr.hpp>
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "supernode.sendsupernodestaketxsrequest"
+
+namespace {
+    static const char* PATH = "/send_supernode_stake_txs";
+}
+
+namespace graft::supernode::request {
+
+namespace
+{
+
+Status supernodeStakeTransactionsHandler
+ (const Router::vars_t& vars,
+  const graft::Input& input,
+  graft::Context& ctx,
+  graft::Output& output)
+{
+    LOG_PRINT_L1(PATH << " called with payload: " << input.data());
+
+    boost::shared_ptr<FullSupernodeList> fsl = ctx.global.get("fsl", boost::shared_ptr<FullSupernodeList>());
+    SupernodePtr supernode = ctx.global.get("supernode", SupernodePtr());
+
+    if (!fsl.get()) {
+        LOG_ERROR("Internal error. Supernode list object missing");
+        return Status::Error;
+    }
+
+    if (!supernode.get()) {
+       LOG_ERROR("Internal error. Supernode object missing");
+       return Status::Error;
+    }
+
+    SendSupernodeStakeTransactionsJsonRpcRequest req;
+
+    if (!input.get(req))
+    { 
+        // can't parse request
+        LOG_ERROR("Failed to parse request");
+        return Status::Error;
+    }
+
+    //  handle stake Transactions
+    const std::vector<SupernodeStakeTransaction>& stake_txs = req.params.stake_txs;
+
+    for (const SupernodeStakeTransaction& tx : stake_txs)
+    {
+        if (!fsl->exists(tx.supernode_public_address))
+            continue;
+
+        // check if supernode currently busy
+        SupernodePtr sn = fsl->get(tx.supernode_public_address);
+
+        if (sn->busy()) {
+            MWARNING("Unable to update supernode with new stake transactions: " << tx.supernode_public_address << ", BUSY");
+            return Status::Error;
+        }
+
+        //TODO: should check supernode == sn?
+
+        sn->setStakeTransactionBlockHeight(tx.block_height);
+        sn->setStakeTransactionUnlockTime(tx.unlock_time);
+    }
+
+    return Status::Ok;
+}
+
+}
+
+void registerSendSupernodeStakeTransactionsRequest(graft::Router &router)
+{
+    Router::Handler3 h3(nullptr, supernodeStakeTransactionsHandler, nullptr);
+
+    router.addRoute(PATH, METHOD_POST, h3);
+
+    LOG_PRINT_L0("route " << PATH << " registered");
+}
+
+}

--- a/src/supernode/requests/send_supernode_stake_txs.cpp
+++ b/src/supernode/requests/send_supernode_stake_txs.cpp
@@ -91,7 +91,6 @@ Status supernodeStakeTransactionsHandler
         dst_tx.unlock_time              = src_tx.unlock_time;
         dst_tx.supernode_public_id      = src_tx.supernode_public_id;
         dst_tx.supernode_public_address = src_tx.supernode_public_address;
-        dst_tx.supernode_signature      = src_tx.supernode_signature;
 
         dst_stake_txs.emplace_back(std::move(dst_tx));
     }

--- a/src/supernode/supernode.cpp
+++ b/src/supernode/supernode.cpp
@@ -127,6 +127,35 @@ void Supernode::initMisc(ConfigOpts& configOpts)
     auto deferred_task = [duration, this] () { std::this_thread::sleep_for(duration); this->loadStakeWallets(); };
     std::thread t(deferred_task);
     t.detach();
+
+    requestStakeTransactions();
+}
+
+void Supernode::requestStakeTransactions()
+{
+    auto handler = [](const graft::Router::vars_t& vars, const graft::Input& input, graft::Context& ctx, graft::Output& output)->graft::Status
+    {
+        graft::SupernodePtr supernode = ctx.global.get(CONTEXT_KEY_SUPERNODE, graft::SupernodePtr(nullptr));
+
+        if (!supernode.get()) {
+            LOG_ERROR("supernode is not set in global context");
+            return graft::Status::Error;
+        }
+
+        if (FullSupernodeListPtr fsl = ctx.global.get(CONTEXT_KEY_FULLSUPERNODELIST, FullSupernodeListPtr()))
+        {
+            fsl->refreshStakeTransactions(supernode->networkAddress().c_str(), supernode->walletAddress().c_str());
+        }
+
+        return graft::Status::Stop;
+    };
+
+    static const size_t STAKE_TRANSACTIONS_REQUEST_DELAY_MS = 1000;
+
+  getConnectionBase().getLooper().addPeriodicTask(
+                graft::Router::Handler3(nullptr, handler, nullptr),
+                std::chrono::milliseconds(STAKE_TRANSACTIONS_REQUEST_DELAY_MS)
+                );
 }
 
 void Supernode::startSupernodePeriodicTasks()


### PR DESCRIPTION
This PR implements communication part of stake transaction validation between cryptonode and supernode. Supernode processes request send_supernode_stake_txs and updates values stakeTransactionBlockHeight and stakeTransactionUnlockTime in the corresponding Supernode class.