### PR TITLE
fix: using shared io_service for http client in FullSupernodeList

### DIFF
--- a/include/rta/DaemonRpcClient.h
+++ b/include/rta/DaemonRpcClient.h
@@ -45,7 +45,8 @@ namespace graft {
 class DaemonRpcClient
 {
 public:
-    DaemonRpcClient(const std::string &daemon_addr, const std::string &daemon_login, const std::string &daemon_pass);
+    DaemonRpcClient(const std::string &daemon_addr, const std::string &daemon_login, const std::string &daemon_pass,
+                    boost::shared_ptr<boost::asio::io_service> ios);
     virtual ~DaemonRpcClient();
     bool get_tx_from_pool(const std::string &hash_str, cryptonote::transaction &out_tx);
     bool get_tx(const std::string &hash_str, cryptonote::transaction &out_tx, uint64_t &block_num, bool &mined);

--- a/include/rta/fullsupernodelist.h
+++ b/include/rta/fullsupernodelist.h
@@ -30,7 +30,7 @@ public:
     static constexpr int64_t AUTH_SAMPLE_HASH_HEIGHT = 20; // block number for calculating auth sample should be calculated as current block height - AUTH_SAMPLE_HASH_HEIGHT;
     static constexpr int64_t ANNOUNCE_TTL_SECONDS = 60 * 60; // if more than ANNOUNCE_TTL_SECONDS passed from last annouce - supernode excluded from auth sample selection
 
-    FullSupernodeList(const std::string &daemon_address, bool testnet = false);
+    FullSupernodeList(const std::string &daemon_address, boost::shared_ptr<boost::asio::io_service> ios, bool testnet = false);
     ~FullSupernodeList();
     /**
      * @brief add - adds supernode object to a list and owns it. caller doesn't need to delete an object

--- a/include/rta/supernode.h
+++ b/include/rta/supernode.h
@@ -243,6 +243,8 @@ public:
     bool busy() const;
 
 
+    static boost::shared_ptr<boost::asio::io_service> getIoService() { return  m_ioservice; }
+
 private:
     Supernode(bool testnet = false);
 

--- a/src/rta/DaemonRpcClient.cpp
+++ b/src/rta/DaemonRpcClient.cpp
@@ -38,8 +38,10 @@ using namespace std;
 
 namespace graft {
 
-DaemonRpcClient::DaemonRpcClient(const std::string &daemon_addr, const std::string &daemon_login, const std::string &daemon_pass)
-    :  m_rpc_timeout(std::chrono::seconds(30))
+DaemonRpcClient::DaemonRpcClient(const std::string &daemon_addr, const std::string &daemon_login, const std::string &daemon_pass,
+                                 boost::shared_ptr<boost::asio::io_service> ios)
+    : m_http_client(ios)
+    , m_rpc_timeout(std::chrono::seconds(30))
 {
 
     boost::shared_mutex mutex;

--- a/src/rta/fullsupernodelist.cpp
+++ b/src/rta/fullsupernodelist.cpp
@@ -123,10 +123,10 @@ constexpr int32_t FullSupernodeList::TIERS, FullSupernodeList::ITEMS_PER_TIER, F
 constexpr int64_t FullSupernodeList::AUTH_SAMPLE_HASH_HEIGHT, FullSupernodeList::ANNOUNCE_TTL_SECONDS;
 #endif
 
-FullSupernodeList::FullSupernodeList(const string &daemon_address, bool testnet)
+FullSupernodeList::FullSupernodeList(const string &daemon_address, boost::shared_ptr<boost::asio::io_service> ios, bool testnet)
     : m_daemon_address(daemon_address)
     , m_testnet(testnet)
-    , m_rpc_client(daemon_address, "", "")
+    , m_rpc_client(daemon_address, "", "", ios)
     , m_tp(new utils::ThreadPool())
 {
     m_refresh_counter = 0;

--- a/src/supernode/supernode.cpp
+++ b/src/supernode/supernode.cpp
@@ -103,7 +103,8 @@ void Supernode::prepareDataDir()
 
     // create fullsupernode list instance and put it into global context
     graft::FullSupernodeListPtr fsl = boost::make_shared<graft::FullSupernodeList>(
-                m_configEx.cryptonode_rpc_address, m_configEx.testnet);
+                m_configEx.cryptonode_rpc_address, graft::Supernode::getIoService(),
+                m_configEx.testnet);
 
     fsl->add(supernode);
 


### PR DESCRIPTION
Very first `DaemonRpcClient::get_block_hash` call (issued by `FullSupernodeList` while building auth sample) failed in most cases due fail in epee's http client; This is the fix for the issue
