### PR TITLE
Make graft-ng usable on 1-core systems

### DIFF
--- a/include/lib/graft/thread_pool/thread_pool_options.hpp
+++ b/include/lib/graft/thread_pool/thread_pool_options.hpp
@@ -60,7 +60,7 @@ private:
 /// Implementation
 
 inline ThreadPoolOptions::ThreadPoolOptions()
-    : m_thread_count(std::max<size_t>(1u, std::thread::hardware_concurrency()))
+    : m_thread_count(std::max<size_t>(2u, std::thread::hardware_concurrency()))
     , m_queue_size(1024u)
     , m_workers_expelling_interval_ms(1000u)
 {
@@ -68,7 +68,7 @@ inline ThreadPoolOptions::ThreadPoolOptions()
 
 inline void ThreadPoolOptions::setThreadCount(size_t count)
 {
-    m_thread_count = std::max<size_t>(1u, count);
+    m_thread_count = std::max<size_t>(2u, count);
 }
 
 inline void ThreadPoolOptions::setQueueSize(size_t size)

--- a/src/lib/graft/task.cpp
+++ b/src/lib/graft/task.cpp
@@ -843,7 +843,7 @@ void TaskManager::onClientDone(BaseTaskPtr bt)
 void TaskManager::initThreadPool(int threadCount, int workersQueueSize, int expellingIntervalMs)
 {
     if(threadCount <= 0) threadCount = std::thread::hardware_concurrency();
-    threadCount = next_pow2(threadCount);
+    threadCount = std::max(size_t(2), next_pow2(threadCount));
     if(workersQueueSize <= 0) workersQueueSize = 32;
 
     tp::ThreadPoolOptions th_op;


### PR DESCRIPTION
A count < 2 throws an error in MPMCBoundedQueue for some reason.  This sets the minimum threads to 2, allowing graft-ng to run on 1-core systems.